### PR TITLE
Added Schema property to ValidationError

### DIFF
--- a/src/NJsonSchema.Tests/Validation/ArrayValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ArrayValidationTests.cs
@@ -56,6 +56,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.ArrayExpected, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -99,6 +100,7 @@ namespace NJsonSchema.Tests.Validation
             //// Assert
             Assert.AreEqual(1, errors.Count());
             Assert.AreEqual(ValidationErrorKind.TooManyItemsInTuple, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -145,6 +147,7 @@ namespace NJsonSchema.Tests.Validation
             Assert.AreEqual(ValidationErrorKind.StringExpected, firstItemError.Kind);
             Assert.AreEqual("[1]", errors.First().Property);
             Assert.AreEqual("#/[1]", errors.First().Path);
+            Assert.AreSame(schema.Item, errors.First().Schema);
         }
 
         [TestMethod]
@@ -167,6 +170,7 @@ namespace NJsonSchema.Tests.Validation
             //// Assert
             Assert.AreEqual(1, errors.Count());
             Assert.AreEqual(ValidationErrorKind.TooManyItems, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -188,6 +192,7 @@ namespace NJsonSchema.Tests.Validation
             //// Assert
             Assert.AreEqual(1, errors.Count());
             Assert.AreEqual(ValidationErrorKind.TooFewItems, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -210,6 +215,7 @@ namespace NJsonSchema.Tests.Validation
             //// Assert
             Assert.AreEqual(1, errors.Count());
             Assert.AreEqual(ValidationErrorKind.ItemsNotUnique, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]

--- a/src/NJsonSchema.Tests/Validation/InheritanceTests.cs
+++ b/src/NJsonSchema.Tests/Validation/InheritanceTests.cs
@@ -53,7 +53,9 @@ namespace NJsonSchema.Tests.Validation
             //// Assert
             var error = (ChildSchemaValidationError)errors.First();
             Assert.AreEqual(ValidationErrorKind.NotAnyOf, error.Kind);
+            Assert.AreSame(schema, error.Schema);
             Assert.AreEqual(ValidationErrorKind.StringExpected, error.Errors.First().Value.First().Kind);
+            Assert.AreSame(schema.AnyOf.First(), error.Errors.First().Value.First().Schema);
         }
         
         [TestMethod]
@@ -100,6 +102,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NotAllOf, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -146,6 +149,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NotOneOf, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -173,6 +177,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NotOneOf, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -192,6 +197,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.ExcludedSchemaValidates, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]

--- a/src/NJsonSchema.Tests/Validation/SchemaTests.cs
+++ b/src/NJsonSchema.Tests/Validation/SchemaTests.cs
@@ -339,6 +339,7 @@ namespace NJsonSchema.Tests.Validation
             //// Assert
             Assert.IsNotNull(error);
             Assert.AreEqual("#/Key", error.Path);
+            Assert.AreSame(schema, error.Schema);
         }
     }
 }

--- a/src/NJsonSchema.Tests/Validation/ValueTypeValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/ValueTypeValidationTests.cs
@@ -38,6 +38,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.StringExpected, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -70,6 +71,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NumberExpected, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -102,6 +104,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.IntegerExpected, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -134,6 +137,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.BooleanExpected, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -151,6 +155,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.PatternMismatch, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -168,6 +173,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.StringTooShort, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -185,6 +191,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.StringTooLong, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -202,6 +209,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NumberTooSmall, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -219,6 +227,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NumberTooBig, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -236,6 +245,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NumberTooSmall, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -253,6 +263,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NumberTooBig, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
 
         [TestMethod]
@@ -272,6 +283,7 @@ namespace NJsonSchema.Tests.Validation
 
             //// Assert
             Assert.AreEqual(ValidationErrorKind.NotInEnumeration, errors.First().Kind);
+            Assert.AreSame(schema, errors.First().Schema);
         }
         
         [TestMethod]

--- a/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
+++ b/src/NJsonSchema/Validation/ChildSchemaValidationError.cs
@@ -20,14 +20,30 @@ namespace NJsonSchema.Validation
         /// <param name="path">The property path. </param>
         /// <param name="errors">The error list. </param>
         /// <param name="token">The token that failed to validate. </param>
+        /// <param name="schema">The schema that contains the validation rule.</param>
+#if !LEGACY
+        public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IReadOnlyDictionary<JsonSchema4, ICollection<ValidationError>> errors, JToken token, JsonSchema4 schema)
+#else
+        public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IDictionary<JsonSchema4, ICollection<ValidationError>> errors, JToken token, JsonSchema4 schema)
+#endif
+            : base(kind, property, path, token, schema)
+        {
+            Errors = errors;
+        }
+
+      /// <summary>Initializes a new instance of the <see cref="ValidationError"/> class. </summary>
+      /// <param name="kind">The error kind. </param>
+      /// <param name="property">The property name. </param>
+      /// <param name="path">The property path. </param>
+      /// <param name="errors">The error list. </param>
+      /// <param name="token">The token that failed to validate. </param>
 #if !LEGACY
         public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IReadOnlyDictionary<JsonSchema4, ICollection<ValidationError>> errors, JToken token)
 #else
         public ChildSchemaValidationError(ValidationErrorKind kind, string property, string path, IDictionary<JsonSchema4, ICollection<ValidationError>> errors, JToken token)
 #endif
-            : base(kind, property, path, token)
+            : this(kind, property, path, errors, token, null)
         {
-            Errors = errors;
         }
 
         /// <summary>Gets the errors for each validated subschema. </summary>

--- a/src/NJsonSchema/Validation/ValidationError.cs
+++ b/src/NJsonSchema/Validation/ValidationError.cs
@@ -19,7 +19,8 @@ namespace NJsonSchema.Validation
         /// <param name="propertyName">The property name. </param>
         /// <param name="propertyPath">The property path. </param>
         /// <param name="token">The token that failed to validate. </param>
-        public ValidationError(ValidationErrorKind errorKind, string propertyName, string propertyPath, JToken token)
+        /// <param name="schema">The schema that contains the validation rule.</param>
+        public ValidationError(ValidationErrorKind errorKind, string propertyName, string propertyPath, JToken token, JsonSchema4 schema)
         {
             Kind = errorKind;
             Property = propertyName;
@@ -37,7 +38,19 @@ namespace NJsonSchema.Validation
                 LineNumber = 0;
                 LinePosition = 0;
             }
+
+            Schema = schema;
         }
+
+      /// <summary>Initializes a new instance of the <see cref="ValidationError"/> class. </summary>
+      /// <param name="errorKind">The error kind. </param>
+      /// <param name="propertyName">The property name. </param>
+      /// <param name="propertyPath">The property path. </param>
+      /// <param name="token">The token that failed to validate. </param>
+      public ValidationError(ValidationErrorKind errorKind, string propertyName, string propertyPath, JToken token)
+          : this(errorKind, propertyName, propertyPath, token, null)
+      {
+      }
 
         /// <summary>Gets the error kind. </summary>
         public ValidationErrorKind Kind { get; private set; }
@@ -56,6 +69,9 @@ namespace NJsonSchema.Validation
 
         /// <summary>Gets the line position the validation failed on. </summary>
         public int LinePosition { get; private set; }
+
+        /// <summary>Gets the schema element that contains the validation rule. </summary>
+        public JsonSchema4 Schema { get; private set; }
 
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>


### PR DESCRIPTION
Added Schema property to ValidationError so that it is easier to find the constraint that caused the validation error.

This will allow better localization of the validation errors.
For instance, one can extend the json schema:
```
{
  "properties": {
    "name": {
      "type": "string",
      "regex": "^[\\\\w\\\\d]*$",
      "x-regexMessage": "The name can only contain alphanumeric characters"
    }
  }
}
```

... and then use the extensions from validation errors:

```
ValidationError error = schema.Validate(obj).FirstOrDefault();
if (error?.Kind == ValidationErrorKind.PatternMismatch)
  errorMessage = error.Schema.ExtensionData["x-regexMessage"].ToString();
```