### PR TITLE
Object is newable only if it's not an enumeration

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
@@ -107,7 +107,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
         {
             schema = schema.ActualSchema;
             return (schema.Type.HasFlag(JsonObjectType.Object) || schema.Type == JsonObjectType.None) 
-                && !schema.IsAnyType && !schema.IsDictionary;
+                && !schema.IsAnyType && !schema.IsDictionary && !schema.IsEnumeration;
         }
     }
 }


### PR DESCRIPTION
NSwag generates `<enum name>.fromJS(...)` for string-based enum types that do not have the `fromJS` method, so this should fix it.