### PR TITLE
Introduce SIngleton type

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -39,7 +39,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
         {
             schema = schema.ActualSchema;
 
-            if (schema.IsAnyType)
+            if (schema.IsAnyType || schema.IsSingleton)
                 return "object";
 
             var type = schema.Type;

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -1349,5 +1349,35 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.IsTrue(code.Contains("public int Foo { get; set; }"));
         }
+
+        [TestMethod]
+        public async Task When_oneOf_is_used_as_singleton()
+        {
+            //// Arrange
+            var json =
+@"{
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+	'type': 'object', 
+	'properties': { 
+        'only_one': {
+            'type': 'object',
+            'oneOf': [
+                    {
+                        'type': 'object'
+                    }
+            ],
+            'additionalProperties': false
+        }
+    }
+}";
+            var schema = await JsonSchema4.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { ClassStyle = CSharpClassStyle.Poco });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.IsTrue(code.Contains(@"public object Only_one { get; set; } = new object()"));
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -45,7 +45,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
             schema = schema.ActualSchema;
 
-            if (schema.IsAnyType)
+            if (schema.IsAnyType || schema.IsSingleton)
                 return "any";
 
             var type = schema.Type;

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -699,6 +699,13 @@ namespace NJsonSchema
             }
         }
 
+        /// <summary>Gets a value indicating wether the schema represents a singleton type (a single oneOf statement without allowing extra properties).</summary>
+        [JsonIgnore]
+        public bool IsSingleton => Type.HasFlag(JsonObjectType.Object) &&
+                                   Properties.Count == 0 &&
+                                   AllowAdditionalProperties == false &&
+                                   OneOf.Count > 0;
+
         /// <summary>Gets a value indicating whether the schema represents a dictionary type (no properties and AdditionalProperties contains a schema).</summary>
         [JsonIgnore]
         public bool IsDictionary => Type.HasFlag(JsonObjectType.Object) &&


### PR DESCRIPTION
I'm currently working with JSON schemas and encountered a use case where an object property is allowed to contain ONLY ONE of the provided objects. Which I named the Singleton type, but another name might fit better.

The generated code declares the property type of a Singleton as a (generic) object, which is enough since resolving/downcasting that object falls under application logic.