### PR TITLE
time format fixes RSuter/NJsonSchema#436

### DIFF
--- a/src/NJsonSchema.Tests/Validation/FormatTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatTimeTests.cs
@@ -5,6 +5,10 @@ using NJsonSchema.Validation;
 
 namespace NJsonSchema.Tests.Validation
 {
+    /// <summary>
+    /// Time format tests according to rfc 3339 full-time
+    /// https://tools.ietf.org/html/rfc3339#section-5.6
+    /// </summary>
     [TestClass]
     public class FormatTimeTests
     {
@@ -16,7 +20,7 @@ namespace NJsonSchema.Tests.Validation
             schema.Type = JsonObjectType.String;
             schema.Format = JsonFormatStrings.Time;
 
-            var token = new JValue("test");
+            var token = new JValue("10 am");
 
             //// Act
             var errors = schema.Validate(token);
@@ -26,14 +30,48 @@ namespace NJsonSchema.Tests.Validation
         }
 
         [TestMethod]
-        public void When_format_time_correct_then_validation_succeeds()
+        public void When_format_time_positive_offset_then_validation_succeeds()
         {
             //// Arrange
             var schema = new JsonSchema4();
             schema.Type = JsonObjectType.String;
             schema.Format = JsonFormatStrings.Time;
 
-            var token = new JValue("14:30:00 +02:00");
+            var token = new JValue("14:30:00+02:00");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count());
+        }
+
+        [TestMethod]
+        public void When_format_time_has_negative_offset_succeeds()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.Time;
+
+            var token = new JValue("14:30:00-02:00");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count());
+        }
+
+        [TestMethod]
+        public void When_format_time_is_utc_then_validation_succeeds()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.Time;
+
+            var token = new JValue("14:30:00Z");
 
             //// Act
             var errors = schema.Validate(token);
@@ -50,7 +88,28 @@ namespace NJsonSchema.Tests.Validation
             schema.Type = JsonObjectType.String;
             schema.Format = JsonFormatStrings.Time;
 
-            var token = new JValue("14:30:00.1234567 +02:00");
+            var token = new JValue("14:30:00.1234567+02:00");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count());
+        }
+
+        /// <summary>
+        /// This allows time without a specified timezone. It represents just the 
+        /// partial-time component in the RFC
+        /// </summary>
+        [TestMethod]
+        public void When_format_time_is_not_utc_or_offset_then_validation_succeeds()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.Time;
+
+            var token = new JValue("14:30:00");
 
             //// Act
             var errors = schema.Validate(token);

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -196,7 +196,7 @@ namespace NJsonSchema.Validation
                         if (schema.Format == JsonFormatStrings.Time)
                         {
                             DateTime dateTimeResult;
-                            if (token.Type != JTokenType.Date && DateTime.TryParseExact(value, "HH:mm:ss.FFFFFFF zzz", null, DateTimeStyles.None, out dateTimeResult) == false)
+                            if (token.Type != JTokenType.Date && DateTime.TryParseExact(value, "HH:mm:ss.FFFFFFFK", null, DateTimeStyles.None, out dateTimeResult) == false)
                                 errors.Add(new ValidationError(ValidationErrorKind.TimeExpected, propertyName, propertyPath, token, schema));
                         }
 


### PR DESCRIPTION
This pr validates the time format as specified in json schema v3 and in RFC 3339

https://tools.ietf.org/html/draft-zyp-json-schema-03
https://tools.ietf.org/html/rfc3339#section-5.6

This fixes #436 