### PR TITLE
Added validation for time-span tokens

### DIFF
--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Generation\XmlObjectTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
     <Compile Include="Validation\EnumValidationTests.cs" />
+    <Compile Include="Validation\FormatTimeSpanTests.cs" />
     <Compile Include="Validation\FormatTimeTests.cs" />
     <Compile Include="Validation\FormatDateTests.cs" />
     <Compile Include="Validation\LineInformationTest.cs" />

--- a/src/NJsonSchema.Tests/Validation/FormatTimeSpanTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatTimeSpanTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using NJsonSchema.Validation;
+
+namespace NJsonSchema.Tests.Validation
+{
+    [TestClass]
+    public class FormatTimeSpanTests
+    {
+        [TestMethod]
+        public void When_format_time_span_incorrect_then_validation_fails()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.TimeSpan;
+
+            var token = new JValue("test");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(ValidationErrorKind.TimeSpanExpected, errors.First().Kind);
+        }
+
+        [TestMethod]
+        public void When_format_time_span_correct_then_validation_succeeds()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.TimeSpan;
+
+            var token = new JValue("1:30:45");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.AreEqual(0, errors.Count());
+        }
+    }
+}

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -200,6 +200,13 @@ namespace NJsonSchema.Validation
                                 errors.Add(new ValidationError(ValidationErrorKind.TimeExpected, propertyName, propertyPath, token, schema));
                         }
 
+                        if (schema.Format == JsonFormatStrings.TimeSpan)
+                        {
+                            TimeSpan timeSpanResult;
+                            if (token.Type != JTokenType.TimeSpan && TimeSpan.TryParse(value, out timeSpanResult) == false)
+                                errors.Add(new ValidationError(ValidationErrorKind.TimeSpanExpected, propertyName, propertyPath, token, schema));
+                        }
+
                         if (schema.Format == JsonFormatStrings.Uri)
                         {
                             Uri uriResult;

--- a/src/NJsonSchema/Validation/ValidationErrorKind.cs
+++ b/src/NJsonSchema/Validation/ValidationErrorKind.cs
@@ -74,6 +74,9 @@ namespace NJsonSchema.Validation
         /// <summary>A time is expected. </summary>
         TimeExpected,
 
+        /// <summary>A time-span is expected. </summary>
+        TimeSpanExpected,
+
         /// <summary>An URI is expected. </summary>
         UriExpected,
 


### PR DESCRIPTION
Fixes RSuter/NJsonSchema#439.