### PR TITLE
Test that shows CSharpGenerator currently fails for integer properties with default values

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpDefaultValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpDefaultValueGenerator.cs
@@ -49,21 +49,40 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Converts the default value to a C# number literal. </summary>
         /// <param name="value">The value to convert.</param>
+        /// <param name="format">Optional schema format</param>
         /// <returns>The C# number literal.</returns>
-        protected override string ConvertNumericValue(object value)
+        protected override string ConvertNumericValue(object value, string format)
         {
-            if (value is byte) return "(byte)" + ((byte)value).ToString(CultureInfo.InvariantCulture);
-            if (value is sbyte) return "(sbyte)" + ((sbyte)value).ToString(CultureInfo.InvariantCulture);
-            if (value is short) return "(short)" + ((short)value).ToString(CultureInfo.InvariantCulture);
-            if (value is ushort) return "(ushort)" + ((ushort)value).ToString(CultureInfo.InvariantCulture);
-            if (value is int) return ((int)value).ToString(CultureInfo.InvariantCulture);
-            if (value is uint) return ((uint)value).ToString(CultureInfo.InvariantCulture) + "U";
-            if (value is long) return ((long)value).ToString(CultureInfo.InvariantCulture) + "L";
-            if (value is ulong) return ((ulong)value).ToString(CultureInfo.InvariantCulture) + "UL";
-            if (value is float) return ((float)value).ToString("r", CultureInfo.InvariantCulture) + "F";
-            if (value is double) return ((double)value).ToString("r", CultureInfo.InvariantCulture) + "D";
-            if (value is decimal) return ((decimal)value).ToString(CultureInfo.InvariantCulture) + "M";
-            return null;
+            if (string.IsNullOrEmpty(format))
+            {
+                if (value is byte) return "(byte)" + ((byte) value).ToString(CultureInfo.InvariantCulture);
+                if (value is sbyte) return "(sbyte)" + ((sbyte) value).ToString(CultureInfo.InvariantCulture);
+                if (value is short) return "(short)" + ((short) value).ToString(CultureInfo.InvariantCulture);
+                if (value is ushort) return "(ushort)" + ((ushort) value).ToString(CultureInfo.InvariantCulture);
+                if (value is int) return ((int) value).ToString(CultureInfo.InvariantCulture);
+                if (value is uint) return ((uint) value).ToString(CultureInfo.InvariantCulture) + "U";
+                if (value is long) return ((long) value).ToString(CultureInfo.InvariantCulture) + "L";
+                if (value is ulong) return ((ulong) value).ToString(CultureInfo.InvariantCulture) + "UL";
+                if (value is float) return ((float) value).ToString("r", CultureInfo.InvariantCulture) + "F";
+                if (value is double) return ((double) value).ToString("r", CultureInfo.InvariantCulture) + "D";
+                if (value is decimal) return ((decimal) value).ToString(CultureInfo.InvariantCulture) + "M";
+                return null;
+            }
+            switch (format)
+            {
+                case JsonFormatStrings.Byte:
+                    return "(byte)" + ((byte)value).ToString(CultureInfo.InvariantCulture);
+                case JsonFormatStrings.Integer:
+                    return ((long)value).ToString(CultureInfo.InvariantCulture);
+                case JsonFormatStrings.Long:
+                    return ((long)value).ToString(CultureInfo.InvariantCulture) + "L";
+                case JsonFormatStrings.Double:
+                    return ((double)value).ToString("r", CultureInfo.InvariantCulture) + "D";
+                case JsonFormatStrings.Decimal:
+                    return ((decimal)value).ToString(CultureInfo.InvariantCulture) + "M";
+                default:
+                    return null;
+            }
         }
 
         /// <summary>Gets the enum default value.</summary>

--- a/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/CSharp/CSharpGeneratorTests.cs
@@ -259,6 +259,30 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         }
 
         [TestMethod]
+        public async Task When_property_has_interger_default_it_is_reflected_in_the_poco()
+        {
+            var data = @"{'properties': {
+                                'intergerWithDefault': {      
+                                    'type': 'integer',
+                                    'format': 'int32',
+                                    'default': 5
+                                 }
+                             }}";
+
+            var schema = await JsonSchema4.FromJsonAsync(data);
+            var settings = new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                Namespace = "ns",
+                GenerateDefaultValues = true
+            };
+            var gen = new CSharpGenerator(schema, settings);
+            var output = gen.GenerateFile("MyClass");
+
+            Assert.IsTrue(output.Contains("public int IntergerWithDefault { get; set; } = 5;"));
+        }
+
+        [TestMethod]
         public async Task When_property_has_boolean_default_it_is_reflected_in_the_poco()
         {
             var data = @"{'properties': {

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptDefaultValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptDefaultValueGenerator.cs
@@ -50,8 +50,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
         /// <summary>Converts the default value to a TypeScript number literal. </summary>
         /// <param name="value">The value to convert.</param>
+        /// <param name="format">Optional schema format</param>
         /// <returns>The TypeScript number literal.</returns>
-        protected override string ConvertNumericValue(object value)
+        protected override string ConvertNumericValue(object value, string format)
         {
             if (value is byte) return ((byte)value).ToString(CultureInfo.InvariantCulture);
             if (value is sbyte) return ((sbyte)value).ToString(CultureInfo.InvariantCulture);

--- a/src/NJsonSchema.CodeGeneration/DefaultValueGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultValueGenerator.cs
@@ -47,15 +47,16 @@ namespace NJsonSchema.CodeGeneration
                 return schema.Default.ToString().ToLowerInvariant();
             if (schema.Type.HasFlag(JsonObjectType.Integer) ||
                 schema.Type.HasFlag(JsonObjectType.Number))
-                return ConvertNumericValue(schema.Default);
+                return ConvertNumericValue(schema.Default, schema.Format);
 
             return null;
         }
 
         /// <summary>Converts the default value to a number literal. </summary>
         /// <param name="value">The value to convert.</param>
+        /// <param name="format">Optional schema format</param>
         /// <returns>The number literal.</returns>
-        protected abstract string ConvertNumericValue(object value);
+        protected abstract string ConvertNumericValue(object value, string format);
 
         /// <summary>Gets the enum default value.</summary>
         /// <param name="schema">The schema.</param>


### PR DESCRIPTION
Tries to assign a long to an int property.
Currently generates this invalid c# code:
```csharp
public int IntergerWithDefault { get; set; } = 5L;
```