### PR TITLE
Implement 'date' type handling for Typescript CodeGeneration

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Samples\SampleTests.cs" />
     <Compile Include="TypeScript\ClassGenerationTests.cs" />
     <Compile Include="TypeScript\ClassOrderTests.cs" />
+    <Compile Include="TypeScript\DateTimeCodeGenerationTests.cs" />
     <Compile Include="TypeScript\DateCodeGenerationTests.cs" />
     <Compile Include="TypeScript\DictionaryTests.cs" />
     <Compile Include="TypeScript\ExtensionCodeTests.cs" />

--- a/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateCodeGenerationTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema.CodeGeneration.TypeScript;
 
 namespace NJsonSchema.CodeGeneration.Tests.TypeScript
@@ -8,17 +9,18 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
     {
         private const string Json =
 @"{
-	""type"": ""object"", 
-	""properties"": {
-		""myDate"": ""2017-01-01""
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+	'type': 'object', 
+	'properties': {
+		'myDate': { 'type': 'string', 'format': 'date' }
 	}
 }";
 
         [TestMethod]
-        public void When_date_handling_is_string_then_string_property_are_generated_in_class()
+        public async Task When_date_handling_is_string_then_string_property_are_generated_in_class()
         {
             //// Arrange
-            var schema = JsonSchema4.FromData(Json);
+            var schema = await JsonSchema4.FromJsonAsync(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -35,10 +37,10 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
         }
 
         [TestMethod]
-        public void When_date_handling_is_moment_then_moment_property_are_generated_in_class()
+        public async Task When_date_handling_is_moment_then_moment_property_are_generated_in_class()
         {
             //// Arrange
-            var schema = JsonSchema4.FromData(Json);
+            var schema = await JsonSchema4.FromJsonAsync(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -55,10 +57,10 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
         }
 
         [TestMethod]
-        public void When_date_handling_is_date_then_date_property_are_generated_in_class()
+        public async Task When_date_handling_is_date_then_date_property_are_generated_in_class()
         {
             //// Arrange
-            var schema = JsonSchema4.FromData(Json);
+            var schema = await JsonSchema4.FromJsonAsync(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -75,10 +77,10 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
         }
 
         [TestMethod]
-        public void When_date_handling_is_date_then_date_property_are_generated_in_interface()
+        public async Task When_date_handling_is_date_then_date_property_are_generated_in_interface()
         {
             //// Arrange
-            var schema = JsonSchema4.FromData(Json);
+            var schema = await JsonSchema4.FromJsonAsync(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -93,10 +95,10 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
         }
 
         [TestMethod]
-        public void When_date_handling_is_moment_then_moment_property_are_generated_in_interface()
+        public async Task When_date_handling_is_moment_then_moment_property_are_generated_in_interface()
         {
             //// Arrange
-            var schema = JsonSchema4.FromData(Json);
+            var schema = await JsonSchema4.FromJsonAsync(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -112,10 +114,10 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
 
 
         [TestMethod]
-        public void When_date_handling_is_string_then_string_property_are_generated_in_interface()
+        public async Task When_date_handling_is_string_then_string_property_are_generated_in_interface()
         {
             //// Arrange
-            var schema = JsonSchema4.FromData(Json);
+            var schema = await JsonSchema4.FromJsonAsync(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings

--- a/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateCodeGenerationTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema.CodeGeneration.TypeScript;
 
 namespace NJsonSchema.CodeGeneration.Tests.TypeScript
@@ -8,16 +6,19 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
     [TestClass]
     public class DateCodeGenerationTests
     {
-        public class ClassWithDateProperty
-        {
-            public DateTime MyDateTime { get; set; }
-        }
+        private const string Json =
+@"{
+	""type"": ""object"", 
+	""properties"": {
+		""myDate"": ""2017-01-01""
+	}
+}";
 
         [TestMethod]
-        public async Task When_date_handling_is_string_then_string_property_are_generated_in_class()
+        public void When_date_handling_is_string_then_string_property_are_generated_in_class()
         {
             //// Arrange
-            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateProperty>();
+            var schema = JsonSchema4.FromData(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -28,16 +29,16 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.IsTrue(code.Contains("myDateTime: string"));
-            Assert.IsTrue(code.Contains("this.myDateTime = data[\"MyDateTime\"];"));
-            Assert.IsTrue(code.Contains("data[\"MyDateTime\"] = this.myDateTime;"));
+            Assert.IsTrue(code.Contains("myDate: string"));
+            Assert.IsTrue(code.Contains("this.myDate = data[\"myDate\"];"));
+            Assert.IsTrue(code.Contains("data[\"myDate\"] = this.myDate;"));
         }
 
         [TestMethod]
-        public async Task When_date_handling_is_moment_then_moment_property_are_generated_in_class()
+        public void When_date_handling_is_moment_then_moment_property_are_generated_in_class()
         {
             //// Arrange
-            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateProperty>();
+            var schema = JsonSchema4.FromData(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -48,16 +49,16 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.IsTrue(code.Contains("myDateTime: moment.Moment"));
-            Assert.IsTrue(code.Contains("this.myDateTime = data[\"MyDateTime\"] ? moment(data[\"MyDateTime\"].toString()) : <any>undefined;"));
-            Assert.IsTrue(code.Contains("data[\"MyDateTime\"] = this.myDateTime ? this.myDateTime.toISOString() : <any>undefined;"));
+            Assert.IsTrue(code.Contains("myDate: moment.Moment"));
+            Assert.IsTrue(code.Contains("this.myDate = data[\"myDate\"] ? moment(data[\"myDate\"].toString()) : <any>undefined;"));
+            Assert.IsTrue(code.Contains("data[\"myDate\"] = this.myDate ? this.myDate.toISOString().slice(0, 10) : <any>undefined;"));
         }
 
         [TestMethod]
-        public async Task When_date_handling_is_date_then_date_property_are_generated_in_class()
+        public void When_date_handling_is_date_then_date_property_are_generated_in_class()
         {
             //// Arrange
-            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateProperty>();
+            var schema = JsonSchema4.FromData(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -68,16 +69,16 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.IsTrue(code.Contains("myDateTime: Date"));
-            Assert.IsTrue(code.Contains("this.myDateTime = data[\"MyDateTime\"] ? new Date(data[\"MyDateTime\"].toString()) : <any>undefined;"));
-            Assert.IsTrue(code.Contains("data[\"MyDateTime\"] = this.myDateTime ? this.myDateTime.toISOString() : <any>undefined;"));
+            Assert.IsTrue(code.Contains("myDate: Date"));
+            Assert.IsTrue(code.Contains("this.myDate = data[\"myDate\"] ? new Date(data[\"myDate\"].toString()) : <any>undefined;"));
+            Assert.IsTrue(code.Contains("data[\"myDate\"] = this.myDate ? this.myDate.toISOString().slice(0, 10) : <any>undefined;"));
         }
 
         [TestMethod]
-        public async Task When_date_handling_is_date_then_date_property_are_generated_in_interface()
+        public void When_date_handling_is_date_then_date_property_are_generated_in_interface()
         {
             //// Arrange
-            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateProperty>();
+            var schema = JsonSchema4.FromData(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -88,14 +89,14 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.IsTrue(code.Contains("MyDateTime: Date;"));
+            Assert.IsTrue(code.Contains("myDate: Date;"));
         }
 
         [TestMethod]
-        public async Task When_date_handling_is_moment_then_moment_property_are_generated_in_interface()
+        public void When_date_handling_is_moment_then_moment_property_are_generated_in_interface()
         {
             //// Arrange
-            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateProperty>();
+            var schema = JsonSchema4.FromData(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -106,15 +107,15 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.IsTrue(code.Contains("MyDateTime: moment.Moment;"));
+            Assert.IsTrue(code.Contains("myDate: moment.Moment;"));
         }
 
 
         [TestMethod]
-        public async Task When_date_handling_is_string_then_string_property_are_generated_in_interface()
+        public void When_date_handling_is_string_then_string_property_are_generated_in_interface()
         {
             //// Arrange
-            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateProperty>();
+            var schema = JsonSchema4.FromData(Json);
 
             //// Act
             var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
@@ -125,7 +126,7 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.IsTrue(code.Contains("MyDateTime: string;"));
+            Assert.IsTrue(code.Contains("myDate: string;"));
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateTimeCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateTimeCodeGenerationTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema.CodeGeneration.TypeScript;
+
+namespace NJsonSchema.CodeGeneration.Tests.TypeScript
+{
+    [TestClass]
+    public class DateTimeCodeGenerationTests
+    {
+        public class ClassWithDateTimeProperty
+        {
+            public DateTime MyDateTime { get; set; }
+        }
+
+        [TestMethod]
+        public async Task When_date_handling_is_string_then_string_property_are_generated_in_class()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateTimeProperty>();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Class,
+                DateTimeType = TypeScriptDateTimeType.String
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.IsTrue(code.Contains("myDateTime: string"));
+            Assert.IsTrue(code.Contains("this.myDateTime = data[\"MyDateTime\"];"));
+            Assert.IsTrue(code.Contains("data[\"MyDateTime\"] = this.myDateTime;"));
+        }
+
+        [TestMethod]
+        public async Task When_date_handling_is_moment_then_moment_property_are_generated_in_class()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateTimeProperty>();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Class,
+                DateTimeType = TypeScriptDateTimeType.MomentJS
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.IsTrue(code.Contains("myDateTime: moment.Moment"));
+            Assert.IsTrue(code.Contains("this.myDateTime = data[\"MyDateTime\"] ? moment(data[\"MyDateTime\"].toString()) : <any>undefined;"));
+            Assert.IsTrue(code.Contains("data[\"MyDateTime\"] = this.myDateTime ? this.myDateTime.toISOString() : <any>undefined;"));
+        }
+
+        [TestMethod]
+        public async Task When_date_handling_is_date_then_date_property_are_generated_in_class()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateTimeProperty>();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Class,
+                //DateTimeType = TypeScriptDateTimeType.Date
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.IsTrue(code.Contains("myDateTime: Date"));
+            Assert.IsTrue(code.Contains("this.myDateTime = data[\"MyDateTime\"] ? new Date(data[\"MyDateTime\"].toString()) : <any>undefined;"));
+            Assert.IsTrue(code.Contains("data[\"MyDateTime\"] = this.myDateTime ? this.myDateTime.toISOString() : <any>undefined;"));
+        }
+
+        [TestMethod]
+        public async Task When_date_handling_is_date_then_date_property_are_generated_in_interface()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateTimeProperty>();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Interface,
+                //DateTimeType = TypeScriptDateTimeType.Date 
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.IsTrue(code.Contains("MyDateTime: Date;"));
+        }
+
+        [TestMethod]
+        public async Task When_date_handling_is_moment_then_moment_property_are_generated_in_interface()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateTimeProperty>();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Interface,
+                DateTimeType = TypeScriptDateTimeType.MomentJS
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.IsTrue(code.Contains("MyDateTime: moment.Moment;"));
+        }
+
+
+        [TestMethod]
+        public async Task When_date_handling_is_string_then_string_property_are_generated_in_interface()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithDateTimeProperty>();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings
+            {
+                TypeStyle = TypeScriptTypeStyle.Interface,
+                DateTimeType = TypeScriptDateTimeType.String
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.IsTrue(code.Contains("MyDateTime: string;"));
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
@@ -76,6 +76,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 IsArrayItemDate = IsDate(parameters.Schema.Item?.Format, parameters.Settings.DateTimeType),
                 IsArrayItemDateTime = IsDateTime(parameters.Schema.Item?.Format, parameters.Settings.DateTimeType),
 
+                //StringToDateCode is used for date and date-time formats
                 StringToDateCode = parameters.Settings.DateTimeType == TypeScriptDateTimeType.Date ? "new Date" : "moment",
                 DateToStringCode = "toISOString().slice(0, 10)",
                 DateTimeToStringCode = "toISOString()", 

--- a/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
@@ -55,6 +55,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
                 IsNewableObject = IsNewableObject(parameters.Schema),
                 IsDate = IsDate(parameters.Schema.Format, parameters.Settings.DateTimeType),
+                IsDateTime = IsDateTime(parameters.Schema.Format, parameters.Settings.DateTimeType),
 
                 IsDictionary = parameters.Schema.IsDictionary,
                 DictionaryValueType = dictionaryValueType,
@@ -63,6 +64,7 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
                 IsDictionaryValueNewableObject = parameters.Schema.AdditionalPropertiesSchema != null && IsNewableObject(parameters.Schema.AdditionalPropertiesSchema),
                 IsDictionaryValueDate = IsDate(parameters.Schema.AdditionalPropertiesSchema?.ActualSchema?.Format, parameters.Settings.DateTimeType),
+                IsDictionaryValueDateTime = IsDateTime(parameters.Schema.AdditionalPropertiesSchema?.ActualSchema?.Format, parameters.Settings.DateTimeType),
                 IsDictionaryValueNewableArray = parameters.Schema.AdditionalPropertiesSchema?.ActualSchema?.Type.HasFlag(JsonObjectType.Array) == true &&
                     IsNewableObject(parameters.Schema.AdditionalPropertiesSchema.Item),
                 DictionaryValueArrayItemType = parameters.Schema.AdditionalPropertiesSchema?.ActualSchema?.Type.HasFlag(JsonObjectType.Array) == true ?
@@ -72,22 +74,21 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 ArrayItemType = parameters.Resolver.TryResolve(parameters.Schema.Item, parameters.TypeNameHint) ?? "any",
                 IsArrayItemNewableObject = parameters.Schema.Item != null && IsNewableObject(parameters.Schema.Item),
                 IsArrayItemDate = IsDate(parameters.Schema.Item?.Format, parameters.Settings.DateTimeType),
+                IsArrayItemDateTime = IsDateTime(parameters.Schema.Item?.Format, parameters.Settings.DateTimeType),
 
                 StringToDateCode = parameters.Settings.DateTimeType == TypeScriptDateTimeType.Date ? "new Date" : "moment",
-                DateToStringCode = "toISOString()", 
+                DateToStringCode = "toISOString().slice(0, 10)",
+                DateTimeToStringCode = "toISOString()", 
 
                 HandleReferences = parameters.Settings.HandleReferences
             };
         }
 
-        private static bool IsDate(string format, TypeScriptDateTimeType type)
+        private static bool IsDateTime(string format, TypeScriptDateTimeType type)
         {
             // TODO: Make this more generic (see TypeScriptTypeResolver.ResolveString)
             if (type == TypeScriptDateTimeType.Date)
             {
-                if (format == JsonFormatStrings.Date)
-                    return true;
-
                 if (format == JsonFormatStrings.DateTime)
                     return true;
 
@@ -99,9 +100,6 @@ namespace NJsonSchema.CodeGeneration.TypeScript
             }
             else if (type == TypeScriptDateTimeType.MomentJS)
             {
-                if (format == JsonFormatStrings.Date)
-                    return true;
-
                 if (format == JsonFormatStrings.DateTime)
                     return true;
 
@@ -109,6 +107,23 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                     return true;
 
                 if (format == JsonFormatStrings.TimeSpan)
+                    return true;
+            }
+            return false;
+        }
+
+
+        private static bool IsDate(string format, TypeScriptDateTimeType type)
+        {
+            // TODO: Make this more generic (see TypeScriptTypeResolver.ResolveString)
+            if (type == TypeScriptDateTimeType.Date)
+            {
+                if (format == JsonFormatStrings.Date)
+                    return true;
+            }
+            else if (type == TypeScriptDateTimeType.MomentJS)
+            {
+                if (format == JsonFormatStrings.Date)
                     return true;
             }
             return false;

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToClassTemplate.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToClassTemplate.cs
@@ -188,7 +188,7 @@ if(Model.HandleReferences){
             #line hidden
             
             #line 12 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToClassTemplate.tt"
-if(Model.IsArrayItemDate){
+if(Model.IsArrayItemDate || Model.IsArrayItemDateTime){
             
             #line default
             #line hidden
@@ -439,7 +439,7 @@ if(Model.HasDictionaryValueDefaultValue){
             #line hidden
             
             #line 29 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToClassTemplate.tt"
-  if(Model.IsDictionaryValueDate){
+  if(Model.IsDictionaryValueDate || Model.IsDictionaryValueDateTime){
             
             #line default
             #line hidden
@@ -619,7 +619,7 @@ if(Model.HasDictionaryValueDefaultValue){
             this.Write("    ");
             
             #line 42 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToClassTemplate.tt"
-if(Model.IsDate){
+if(Model.IsDate || Model.IsDateTime){
             
             #line default
             #line hidden

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToClassTemplate.tt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToClassTemplate.tt
@@ -9,7 +9,7 @@ if (<#=Model.Value#> && <#=Model.Value#>.constructor === Array) {
 <#if(Model.IsArrayItemNewableObject){#>
         <#=Model.Variable#>.push(<#=Model.ArrayItemType#>.fromJS(item<#if(Model.HandleReferences){#>, _mappings<#}#>));
 <#}else{#>
-<#if(Model.IsArrayItemDate){#>
+<#if(Model.IsArrayItemDate || Model.IsArrayItemDateTime){#>
         <#=Model.Variable#>.push(<#=Model.StringToDateCode#>(item));
 <#}else{#>
         <#=Model.Variable#>.push(item);
@@ -26,7 +26,7 @@ if (<#=Model.Value#>) {
 <#}else if(Model.IsDictionaryValueNewableArray){#>
             <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#=Model.Value#>[key].map((i: any) => <#=Model.DictionaryValueArrayItemType#>.fromJS(i<#if(Model.HandleReferences){#>, _mappings<#}#>)) : <#if(Model.HasDictionaryValueDefaultValue){#><#=Model.DictionaryValueDefaultValue#><#}else{#><any><#=Model.NullValue#><#}#>;
 <#}else{#>
-<#  if(Model.IsDictionaryValueDate){#>
+<#  if(Model.IsDictionaryValueDate || Model.IsDictionaryValueDateTime){#>
             <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#=Model.StringToDateCode#>(<#=Model.Value#>[key].toString()) : <#if(Model.HasDictionaryValueDefaultValue){#><#=Model.DictionaryValueDefaultValue#><#}else{#><any><#=Model.NullValue#><#}#>;
 <#  }else{#>
 <#      if(Model.HasDictionaryValueDefaultValue || Model.NullValue != "undefined"){#>
@@ -39,7 +39,7 @@ if (<#=Model.Value#>) {
     }
 }
 <#}else{#>
-    <#if(Model.IsDate){#>
+    <#if(Model.IsDate || Model.IsDateTime){#>
 <#=Model.Variable#> = <#=Model.Value#> ? <#=Model.StringToDateCode#>(<#=Model.Value#>.toString()) : <#if(Model.HasDefaultValue){#><#=Model.StringToDateCode#>(<#=Model.DefaultValue#>)<#}else{#><any><#=Model.NullValue#><#}#>;
     <#}else{#>
 <#      if(Model.HasDefaultValue || Model.NullValue != "undefined"){#>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.cs
@@ -143,7 +143,7 @@ if(Model.IsArrayItemDate){
             this.Write(");\r\n");
             
             #line 14 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
-}else{
+}else if(Model.IsArrayItemDateTime){
             
             #line default
             #line hidden
@@ -154,371 +154,500 @@ if(Model.IsArrayItemDate){
             
             #line default
             #line hidden
-            this.Write(".push(item);\r\n");
+            this.Write(".push(item.");
+            
+            #line 15 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateTimeToStringCode));
+            
+            #line default
+            #line hidden
+            this.Write(");\r\n");
             
             #line 16 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+}else{
+            
+            #line default
+            #line hidden
+            this.Write("        ");
+            
+            #line 17 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
+            
+            #line default
+            #line hidden
+            this.Write(".push(item);\r\n");
+            
+            #line 18 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }}
             
             #line default
             #line hidden
             this.Write("}\r\n");
             
-            #line 18 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 20 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }else{
             
             #line default
             #line hidden
             
-            #line 19 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 21 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 if(Model.IsDictionary){
             
             #line default
             #line hidden
             this.Write("if (");
             
-            #line 20 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 22 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(") {\r\n    ");
             
-            #line 21 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 23 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write(" = {};\r\n    for (let key in ");
             
-            #line 22 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 24 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(") {\r\n        if (");
             
-            #line 23 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 25 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(".hasOwnProperty(key))\r\n");
             
-            #line 24 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 26 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 if(Model.IsDictionaryValueNewableObject){
             
             #line default
             #line hidden
             this.Write("            ");
             
-            #line 25 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 27 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write("[key] = ");
             
-            #line 25 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 27 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write("[key] ? ");
             
-            #line 25 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 27 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write("[key].toJSON() : <any>");
             
-            #line 25 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 27 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.NullValue));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 26 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 28 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }else{
             
             #line default
             #line hidden
             
-            #line 27 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 29 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 if(Model.IsDictionaryValueDate){
             
             #line default
             #line hidden
             this.Write("            ");
             
-            #line 28 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write("[key] = ");
             
-            #line 28 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write("[key] ? ");
             
-            #line 28 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write("[key].");
             
-            #line 28 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateToStringCode));
             
             #line default
             #line hidden
             this.Write(" : <any>");
             
-            #line 28 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.NullValue));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 29 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 31 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+} else if(Model.IsDictionaryValueDateTime){
+            
+            #line default
+            #line hidden
+            this.Write("            ");
+            
+            #line 32 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
+            
+            #line default
+            #line hidden
+            this.Write("[key] = ");
+            
+            #line 32 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
+            
+            #line default
+            #line hidden
+            this.Write("[key] ? ");
+            
+            #line 32 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
+            
+            #line default
+            #line hidden
+            this.Write("[key].");
+            
+            #line 32 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateTimeToStringCode));
+            
+            #line default
+            #line hidden
+            this.Write(" : <any>");
+            
+            #line 32 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.NullValue));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 33 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }else{
             
             #line default
             #line hidden
             
-            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 34 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
   if(Model.NullValue != "undefined"){
             
             #line default
             #line hidden
             this.Write("            ");
             
-            #line 31 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 35 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write("[key] = ");
             
-            #line 31 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 35 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write("[key] !== undefined ? ");
             
-            #line 31 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 35 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write("[key] : <any>");
             
-            #line 31 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 35 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.NullValue));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 32 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 36 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
   }else{
             
             #line default
             #line hidden
             this.Write("            ");
             
-            #line 33 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 37 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write("[key] = ");
             
-            #line 33 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 37 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write("[key];\r\n");
             
-            #line 34 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 38 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
   }
             
             #line default
             #line hidden
             
-            #line 35 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 39 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }}
             
             #line default
             #line hidden
             this.Write("    }\r\n}\r\n");
             
-            #line 38 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 42 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }else{
             
             #line default
             #line hidden
             
-            #line 39 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 43 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
   if(Model.IsDate){
             
             #line default
             #line hidden
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(" ? ");
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateToStringCode));
             
             #line default
             #line hidden
             this.Write(" : ");
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 if(Model.HasDefaultValue){
             
             #line default
             #line hidden
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.DefaultValue));
             
             #line default
             #line hidden
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }else{
             
             #line default
             #line hidden
             this.Write("<any>");
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.NullValue));
             
             #line default
             #line hidden
             
-            #line 40 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 41 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
-  }else{
+            #line 45 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+  } else if(Model.IsDateTime){
             
             #line default
             #line hidden
             
-            #line 42 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
-      if(Model.NullValue != "undefined"){
-            
-            #line default
-            #line hidden
-            
-            #line 43 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 43 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
+            
+            #line default
+            #line hidden
+            this.Write(" ? ");
+            
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
+            
+            #line default
+            #line hidden
+            this.Write(".");
+            
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateTimeToStringCode));
+            
+            #line default
+            #line hidden
+            this.Write(" : ");
+            
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+if(Model.HasDefaultValue){
+            
+            #line default
+            #line hidden
+            
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DefaultValue));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+}else{
+            
+            #line default
+            #line hidden
+            this.Write("<any>");
+            
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.NullValue));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+}
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 47 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+  }else{
+            
+            #line default
+            #line hidden
+            
+            #line 48 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+      if(Model.NullValue != "undefined"){
+            
+            #line default
+            #line hidden
+            
+            #line 49 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
+            
+            #line default
+            #line hidden
+            this.Write(" = ");
+            
+            #line 49 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(" !== undefined ? ");
             
-            #line 43 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 49 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(" : <any>");
             
-            #line 43 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 49 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.NullValue));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 50 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
       }else{
             
             #line default
             #line hidden
             
-            #line 45 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 51 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Variable));
             
             #line default
             #line hidden
             this.Write(" = ");
             
-            #line 45 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 51 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 46 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 52 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
       }
             
             #line default
             #line hidden
             
-            #line 47 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 53 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
   }
             
             #line default
             #line hidden
             
-            #line 48 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 54 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }
             
             #line default
             #line hidden
             
-            #line 49 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 55 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }
             
             #line default
             #line hidden
             
-            #line 50 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            #line 56 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
 }
             
             #line default

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.tt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.tt
@@ -11,6 +11,8 @@ if (<#=Model.Value#> && <#=Model.Value#>.constructor === Array) {
 <#}else{#>
 <#if(Model.IsArrayItemDate){#>
         <#=Model.Variable#>.push(item.<#=Model.DateToStringCode#>);
+<#}else if(Model.IsArrayItemDateTime){#>
+        <#=Model.Variable#>.push(item.<#=Model.DateTimeToStringCode#>);
 <#}else{#>
         <#=Model.Variable#>.push(item);
 <#}}#>
@@ -26,6 +28,8 @@ if (<#=Model.Value#>) {
 <#}else{#>
 <#if(Model.IsDictionaryValueDate){#>
             <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#=Model.Value#>[key].<#=Model.DateToStringCode#> : <any><#=Model.NullValue#>;
+<#} else if(Model.IsDictionaryValueDateTime){#>
+            <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#=Model.Value#>[key].<#=Model.DateTimeToStringCode#> : <any><#=Model.NullValue#>;
 <#}else{#>
 <#  if(Model.NullValue != "undefined"){#>
             <#=Model.Variable#>[key] = <#=Model.Value#>[key] !== undefined ? <#=Model.Value#>[key] : <any><#=Model.NullValue#>;
@@ -38,6 +42,8 @@ if (<#=Model.Value#>) {
 <#}else{#>
 <#  if(Model.IsDate){#>
 <#=Model.Variable#> = <#=Model.Value#> ? <#=Model.Value#>.<#=Model.DateToStringCode#> : <#if(Model.HasDefaultValue){#><#=Model.DefaultValue#><#}else{#><any><#=Model.NullValue#><#}#>;
+<#  } else if(Model.IsDateTime){#>
+<#=Model.Variable#> = <#=Model.Value#> ? <#=Model.Value#>.<#=Model.DateTimeToStringCode#> : <#if(Model.HasDefaultValue){#><#=Model.DefaultValue#><#}else{#><any><#=Model.NullValue#><#}#>;
 <#  }else{#>
 <#      if(Model.NullValue != "undefined"){#>
 <#=Model.Variable#> = <#=Model.Value#> !== undefined ? <#=Model.Value#> : <any><#=Model.NullValue#>;


### PR DESCRIPTION
Fixes #492 

We now have `IsDate` and `IsDateTime`, and use these to generate different code when serializing back to json.

`DateTimeCodeGenerationTests.cs` is the previous `DateCodeGenerationTests.cs` and matches it other than by name.
`DateCodeGenerationTests.cs` is a new lot of tests that check the same things, but for the `date` type.