### PR TITLE
Working towards fixing date formatting #520

### DIFF
--- a/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateCodeGenerationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/TypeScript/DateCodeGenerationTests.cs
@@ -53,7 +53,7 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             //// Assert
             Assert.IsTrue(code.Contains("myDate: moment.Moment"));
             Assert.IsTrue(code.Contains("this.myDate = data[\"myDate\"] ? moment(data[\"myDate\"].toString()) : <any>undefined;"));
-            Assert.IsTrue(code.Contains("data[\"myDate\"] = this.myDate ? this.myDate.toISOString().slice(0, 10) : <any>undefined;"));
+            Assert.IsTrue(code.Contains("data[\"myDate\"] = this.myDate ? this.myDate.format('YYYY-MM-DD') : <any>undefined;"));
         }
 
         [TestMethod]
@@ -73,7 +73,7 @@ namespace NJsonSchema.CodeGeneration.Tests.TypeScript
             //// Assert
             Assert.IsTrue(code.Contains("myDate: Date"));
             Assert.IsTrue(code.Contains("this.myDate = data[\"myDate\"] ? new Date(data[\"myDate\"].toString()) : <any>undefined;"));
-            Assert.IsTrue(code.Contains("data[\"myDate\"] = this.myDate ? this.myDate.toISOString().slice(0, 10) : <any>undefined;"));
+            Assert.IsTrue(code.Contains("data[\"myDate\"] = this.myDate ? formatDate(this.myDate) : <any>undefined;"));
         }
 
         [TestMethod]

--- a/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/DataConversionGenerator.cs
@@ -79,9 +79,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript
                 IsArrayItemDateTime = IsDateTime(parameters.Schema.Item?.Format, parameters.Settings.DateTimeType),
 
                 //StringToDateCode is used for date and date-time formats
+                UseJsDate = parameters.Settings.DateTimeType == TypeScriptDateTimeType.Date,
                 StringToDateCode = parameters.Settings.DateTimeType == TypeScriptDateTimeType.Date ? "new Date" : "moment",
-                DateToStringCode = "toISOString().slice(0, 10)",
-                DateTimeToStringCode = "toISOString()", 
+                DateTimeToStringCode = "toISOString()",
 
                 HandleReferences = parameters.Settings.HandleReferences
             };

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Models/FileTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Models/FileTemplateModel.cs
@@ -41,6 +41,9 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Models
         /// <summary>Gets a value indicating whether to handle JSON references.</summary>
         public bool HandleReferences => _settings.HandleReferences;
 
+        /// <summary>Gets a value indicating whether Date(Time) objects are handled using JS Dates</summary>
+        public bool UseJsDate => _settings.DateTimeType == TypeScriptDateTimeType.Date;
+
         /// <summary>Gets the reference handling code.</summary>
         public string ReferenceHandlingCode => TypeScriptReferenceHandlingCodeGenerator.Generate(); // TODO: Remove after T4 has been removed
     }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.cs
@@ -133,10 +133,24 @@ if(Model.IsArrayItemDate){
             
             #line default
             #line hidden
-            this.Write(".push(item.");
+            this.Write(".push(");
             
             #line 13 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateToStringCode));
+if(Model.UseJsDate){
+            
+            #line default
+            #line hidden
+            this.Write("formatDate(item)");
+            
+            #line 13 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+}else{
+            
+            #line default
+            #line hidden
+            this.Write("item.format(\'YYYY-MM-DD\')");
+            
+            #line 13 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+}
             
             #line default
             #line hidden
@@ -288,14 +302,34 @@ if(Model.IsDictionaryValueDate){
             this.Write("[key] ? ");
             
             #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+if(Model.UseJsDate){
+            
+            #line default
+            #line hidden
+            this.Write("formatDate(");
+            
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
-            this.Write("[key].");
+            this.Write("[key])");
             
             #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateToStringCode));
+}else{
+            
+            #line default
+            #line hidden
+            
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
+            
+            #line default
+            #line hidden
+            this.Write("[key].format(\'YYYY-MM-DD\')");
+            
+            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+}
             
             #line default
             #line hidden
@@ -452,14 +486,34 @@ if(Model.IsDictionaryValueDate){
             this.Write(" ? ");
             
             #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+if(Model.UseJsDate){
+            
+            #line default
+            #line hidden
+            this.Write("formatDate(");
+            
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
             
             #line default
             #line hidden
-            this.Write(".");
+            this.Write(")");
             
             #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DateToStringCode));
+}else{
+            
+            #line default
+            #line hidden
+            
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Value));
+            
+            #line default
+            #line hidden
+            this.Write(".format(\'YYYY-MM-DD\')");
+            
+            #line 44 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\ConvertToJavaScriptTemplate.tt"
+}
             
             #line default
             #line hidden

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.tt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScriptTemplate.tt
@@ -10,7 +10,7 @@ if (<#=Model.Value#> && <#=Model.Value#>.constructor === Array) {
         <#=Model.Variable#>.push(item.toJSON());
 <#}else{#>
 <#if(Model.IsArrayItemDate){#>
-        <#=Model.Variable#>.push(item.<#=Model.DateToStringCode#>);
+        <#=Model.Variable#>.push(<#if(Model.UseJsDate){#>formatDate(item)<#}else{#>item.format('YYYY-MM-DD')<#}#>);
 <#}else if(Model.IsArrayItemDateTime){#>
         <#=Model.Variable#>.push(item.<#=Model.DateTimeToStringCode#>);
 <#}else{#>
@@ -27,7 +27,7 @@ if (<#=Model.Value#>) {
             <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#=Model.Value#>[key].toJSON() : <any><#=Model.NullValue#>;
 <#}else{#>
 <#if(Model.IsDictionaryValueDate){#>
-            <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#=Model.Value#>[key].<#=Model.DateToStringCode#> : <any><#=Model.NullValue#>;
+            <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#if(Model.UseJsDate){#>formatDate(<#=Model.Value#>[key])<#}else{#><#=Model.Value#>[key].format('YYYY-MM-DD')<#}#> : <any><#=Model.NullValue#>;
 <#} else if(Model.IsDictionaryValueDateTime){#>
             <#=Model.Variable#>[key] = <#=Model.Value#>[key] ? <#=Model.Value#>[key].<#=Model.DateTimeToStringCode#> : <any><#=Model.NullValue#>;
 <#}else{#>
@@ -41,7 +41,7 @@ if (<#=Model.Value#>) {
 }
 <#}else{#>
 <#  if(Model.IsDate){#>
-<#=Model.Variable#> = <#=Model.Value#> ? <#=Model.Value#>.<#=Model.DateToStringCode#> : <#if(Model.HasDefaultValue){#><#=Model.DefaultValue#><#}else{#><any><#=Model.NullValue#><#}#>;
+<#=Model.Variable#> = <#=Model.Value#> ? <#if(Model.UseJsDate){#>formatDate(<#=Model.Value#>)<#}else{#><#=Model.Value#>.format('YYYY-MM-DD')<#}#> : <#if(Model.HasDefaultValue){#><#=Model.DefaultValue#><#}else{#><any><#=Model.NullValue#><#}#>;
 <#  } else if(Model.IsDateTime){#>
 <#=Model.Variable#> = <#=Model.Value#> ? <#=Model.Value#>.<#=Model.DateTimeToStringCode#> : <#if(Model.HasDefaultValue){#><#=Model.DefaultValue#><#}else{#><any><#=Model.NullValue#><#}#>;
 <#  }else{#>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/FileTemplate.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/FileTemplate.cs
@@ -43,20 +43,36 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Templates
             this.Write("\r\n\r\n");
             
             #line 10 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+if(Model.UseJsDate){
+            
+            #line default
+            #line hidden
+            this.Write("function formatDate(d: Date) {\r\n\treturn d.getFullYear() + \'-\' + (d.getMonth() < 9" +
+                    " ? (\'0\' + (d.getMonth()+1)) : (d.getMonth()+1)) + \'-\' + (d.getDate() < 10 ? (\'0\'" +
+                    " + d.getDate()) : d.getDate());\r\n}\r\n");
+            
+            #line 14 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+}
+            
+            #line default
+            #line hidden
+            this.Write("\r\n");
+            
+            #line 16 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 if(Model.HasModuleName){
             
             #line default
             #line hidden
             this.Write("module ");
             
-            #line 11 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 17 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.ModuleName));
             
             #line default
             #line hidden
             this.Write(" {\r\n");
             
-            #line 12 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 18 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 }
   if(Model.HasNamespace){
             
@@ -64,68 +80,68 @@ if(Model.HasModuleName){
             #line hidden
             this.Write("namespace ");
             
-            #line 14 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 20 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Namespace));
             
             #line default
             #line hidden
             this.Write(" {\r\n");
             
-            #line 15 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 21 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 }
             
             #line default
             #line hidden
             
-            #line 16 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 22 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.ExtensionCode.TopCode));
             
             #line default
             #line hidden
             this.Write("\r\n\r\n");
             
-            #line 18 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 24 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Types));
             
             #line default
             #line hidden
             this.Write("\r\n\r\n");
             
-            #line 20 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 26 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.ExtensionCode.BottomCode));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 21 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 27 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 if(Model.HandleReferences){
             
             #line default
             #line hidden
             
-            #line 22 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 28 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.ReferenceHandlingCode));
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 23 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 29 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 }
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 25 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 31 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 if(Model.HasNamespace){
             
             #line default
             #line hidden
             this.Write("}\r\n");
             
-            #line 27 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 33 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 }
 if(Model.HasModuleName){
             
@@ -133,7 +149,7 @@ if(Model.HasModuleName){
             #line hidden
             this.Write("}\r\n");
             
-            #line 30 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
+            #line 36 "C:\Data\Projects\NJsonSchema\src\NJsonSchema.CodeGeneration.TypeScript\Templates\FileTemplate.tt"
 }
             
             #line default

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/FileTemplate.tt
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/FileTemplate.tt
@@ -7,6 +7,12 @@
 
 <#=Model.ExtensionCode.ImportCode#>
 
+<#if(Model.UseJsDate){#>
+function formatDate(d: Date) {
+	return d.getFullYear() + '-' + (d.getMonth() < 9 ? ('0' + (d.getMonth()+1)) : (d.getMonth()+1)) + '-' + (d.getDate() < 10 ? ('0' + d.getDate()) : d.getDate());
+}
+<#}#>
+
 <#if(Model.HasModuleName){#>
 module <#=Model.ModuleName#> {
 <#}

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Liquid/ConvertToJavaScriptTemplate.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Liquid/ConvertToJavaScriptTemplate.liquid
@@ -7,7 +7,7 @@ if ({{ Value }} && {{ Value }}.constructor === Array) {
 {%     if IsArrayItemNewableObject -%}
         {{ Variable }}.push(item.toJSON());
 {%     elseif IsArrayItemDate -%}
-        {{ Variable }}.push(item.{{ DateToStringCode }});
+        {{ Variable }}.push({% if UseJsDate %}formatDate(item){% else %}item.format('YYYY-MM-DD'){% endif %});
 {%     elseif IsArrayItemDateTime -%}
         {{ Variable }}.push(item.{{ DateTimeToStringCode }});
 {%     else -%}
@@ -22,7 +22,7 @@ if ({{ Value }}) {
 {%     if IsDictionaryValueNewableObjec -%}
             {{ Variable }}[key] = {{ Value }}[key] ? {{ Value }}[key].toJSON() : <any>{{ NullValue }};
 {%     elseif IsDictionaryValueDate -%}
-            {{ Variable }}[key] = {{ Value }}[key] ? {{ Value }}[key].{{ DateToStringCode }} : <any>{{ NullValue }};
+            {{ Variable }}[key] = {{ Value }}[key] ? {% if UseJsDate %}formatDate({{ Value }}[key]){% else %}{{ Value }}[key].format('YYYY-MM-DD'){% endif %} : <any>{{ NullValue }};
 {%     elseif IsDictionaryValueDateTime -%}
             {{ Variable }}[key] = {{ Value }}[key] ? {{ Value }}[key].{{ DateTimeToStringCode }} : <any>{{ NullValue }};
 {%     else -%}
@@ -35,7 +35,7 @@ if ({{ Value }}) {
     }
 }
 {% elseif IsDate -%}
-{{ Variable }} = {{ Value }} ? {{ Value }}.{{ DateToStringCode }} : {% if HasDefaultValue -%}{{ DefaultValue }}{% else %}<any>{{ NullValue }}{% endif %};
+{{ Variable }} = {{ Value }} ? {% if UseJsDate %}formatDate({{ Value }}){% else %}{{ Value }}.format('YYYY-MM-DD'){% endif %} : {% if HasDefaultValue -%}{{ DefaultValue }}{% else %}<any>{{ NullValue }}{% endif %};
 {% elseif IsDateTime -%}
 {{ Variable }} = {{ Value }} ? {{ Value }}.{{ DateTimeToStringCode }} : {% if HasDefaultValue %}{{ DefaultValue }}{% else %}<any>{{ NullValue }}{% endif %};
 {% elseif NullValue != "undefined" -%}

--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Liquid/File.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/Liquid/File.liquid
@@ -6,6 +6,12 @@
 
 {{ ExtensionCode.ImportCode }}
 
+{% if UseJsDate -%}
+function formatDate(d: Date) {
+	return d.getFullYear() + '-' + (d.getMonth() < 9 ? ('0' + (d.getMonth()+1)) : (d.getMonth()+1)) + '-' + (d.getDate() < 10 ? ('0' + d.getDate()) : d.getDate());
+}
+{% endif -%}
+
 {% if HasModuleName -%}
 module {{ ModuleName }} {
 {% endif -%}


### PR DESCRIPTION
Current NJsonSchema is making all sorts of weird build errors for me (Can't nuget restore DotLiquid 2.0.84 I think?), so I've blind fixed this maybe.

Trouble with fixing it is that the code for formatting a `Date` object can't go all on the right hand side, so I've had to introduce a method and a string replace to plug it in.
Not sure if there is a nicer way to do this?

I also haven't updated the liquid templates or rebuilt the `cs` files from the `tt`.