### PR TITLE
Added support for DisplayNameAttribute for schema title

### DIFF
--- a/src/NJsonSchema.Tests/Conversion/TypeToSchemaTests.cs
+++ b/src/NJsonSchema.Tests/Conversion/TypeToSchemaTests.cs
@@ -242,7 +242,29 @@ namespace NJsonSchema.Tests.Conversion
             Assert.IsTrue(schema.Definitions.Any(d => d.Key == "MySubtype"));
             Assert.AreEqual(JsonObjectType.String | JsonObjectType.Null, property.ActualSchema.Item.ActualSchema.Properties["Id"].Type);
         }
+        
+        [TestMethod]
+        public async Task When_converting_object_with_display_name_then_schema_title_should_be_set()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<MyType>();
 
+            Assert.AreEqual("My Type", schema.Title);
+        }
+
+        [TestMethod]
+        public async Task When_converting_object_with_empty_display_name_then_fallback_to_reflection()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<FallBackDisplayName>();
+
+            Assert.AreEqual(nameof(FallBackDisplayName), schema.Title);
+        }
+
+        [System.ComponentModel.DisplayName]
+        public class FallBackDisplayName
+        {
+        }
+
+        [System.ComponentModel.DisplayName("My Type")]
         public class MyType
         {
             [System.ComponentModel.Description("Test")]

--- a/src/NJsonSchema/DefaultSchemaNameGenerator.cs
+++ b/src/NJsonSchema/DefaultSchemaNameGenerator.cs
@@ -25,6 +25,10 @@ namespace NJsonSchema
             if (!string.IsNullOrEmpty(jsonSchemaAttribute?.Name))
                 return jsonSchemaAttribute.Name;
 
+            dynamic displayNameAttribute = type.GetTypeInfo().GetCustomAttributes().TryGetIfAssignableTo("System.ComponentModel.DisplayNameAttribute");
+            if (displayNameAttribute != null && !string.IsNullOrEmpty(displayNameAttribute.DisplayName))
+                return displayNameAttribute.DisplayName;
+
             //var jsonObjectAttribute = type.GetTypeInfo().GetCustomAttribute<JsonObjectAttribute>();
             //if (!string.IsNullOrEmpty(jsonObjectAttribute.Title) && Regex.IsMatch(jsonObjectAttribute.Title, "^[a-zA-Z0-9_]*$"))
             //    return jsonObjectAttribute.Title;


### PR DESCRIPTION
This adds a nice support to set schema title by using `System.ComponentModel.DisplayName` which resolves #571.

```cs
[DisplayName("My Cool Component")]
public class MyComponent
{
}
```