### PR TITLE
fix validation of enum null values (#575)

### DIFF
--- a/src/NJsonSchema.Tests/Validation/EnumValidationTests.cs
+++ b/src/NJsonSchema.Tests/Validation/EnumValidationTests.cs
@@ -77,5 +77,70 @@ namespace NJsonSchema.Tests.Validation
             //// Assert
             Assert.Equal(1, errors.Count);
         }
+
+        [Fact]
+        public async Task When_enumeration_has_null_and_value_is_null_then_no_validation_errors()
+        {
+            //// Arrange
+            var json = @"
+            {
+                ""properties"": {
+                    ""SalutationType"": {
+                        ""type"": [
+                            ""string"",
+                            ""null""
+                        ],
+                        ""enum"": [
+                            ""Mr"",
+                            ""Mrs"",
+                            ""Dr"",
+                            ""Ms"",
+                            null
+                        ]
+                    }
+                }
+            }";
+
+            //// Act
+            var schema = await JsonSchema4.FromJsonAsync(json);
+
+            //// Act
+            var errors = schema.Validate(@"{ ""SalutationType"": null }");
+
+            //// Assert
+            Assert.Equal(0, errors.Count);
+        }
+
+        [Fact]
+        public async Task When_enumeration_doesnt_have_null_and_value_is_null_then_validation_fails()
+        {
+            //// Arrange
+            var json = @"
+            {
+                ""properties"": {
+                    ""SalutationType"": {
+                        ""type"": [
+                            ""string"",
+                            ""null""
+                        ],
+                        ""enum"": [
+                            ""Mr"",
+                            ""Mrs"",
+                            ""Dr"",
+                            ""Ms""
+                        ]
+                    }
+                }
+            }";
+
+            //// Act
+            var schema = await JsonSchema4.FromJsonAsync(json);
+
+            //// Act
+            var errors = schema.Validate(@"{ ""SalutationType"": null }");
+
+            //// Assert
+            Assert.Equal(1, errors.Count);
+        }
     }
 }

--- a/src/NJsonSchema/Validation/JsonSchemaValidator.cs
+++ b/src/NJsonSchema/Validation/JsonSchemaValidator.cs
@@ -151,6 +151,8 @@ namespace NJsonSchema.Validation
 
         private void ValidateEnum(JToken token, JsonSchema4 schema, string propertyName, string propertyPath, List<ValidationError> errors)
         {
+            if (schema.Enumeration.Contains(null) && token?.Type == JTokenType.Null)
+                return;
             if (schema.Enumeration.Count > 0 && schema.Enumeration.All(v => v?.ToString() != token?.ToString()))
                 errors.Add(new ValidationError(ValidationErrorKind.NotInEnumeration, propertyName, propertyPath, token, schema));
         }


### PR DESCRIPTION
Hello! This is the fix for the #575 issue with two new unit tests.
Not sure if the additional return is allowed by code style rules.