### PR TITLE
Proposed fix to handle parsing json files with a dash in the name.

### DIFF
--- a/src/NJsonSchema/ConversionUtilities.cs
+++ b/src/NJsonSchema/ConversionUtilities.cs
@@ -27,6 +27,9 @@ namespace NJsonSchema
                 .Replace(" ", "_")
                 .Replace("/", "_"));
 
+            if (string.IsNullOrEmpty(input))
+                return string.Empty;
+
             if (firstCharacterMustBeAlpha && char.IsNumber(input[0]))
                 return "_" + input;
 


### PR DESCRIPTION
In ConversionUtilities after the call to ConvertDashesToCamelCase the input string can be empty, an extra check has to be added to prevent an IndexOutOfRangeException in the following statements.

This occurs when parsing a json filename with a space, dash space (" - ") in the name.

This is only a proposed fix. It might be better to change the ConvertDashesToCamelCase function but that function is used in many different places so I could not predict further impact on other processes.