### PR TITLE
Use discriminator key from inheritance attribute when serializing

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
@@ -90,10 +90,10 @@ internal class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
 
     private System.Type GetObjectSubtype(System.Type objectType, string discriminator)
     {
-        foreach (var type in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
+        foreach (var attribute in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
         {
-            if (type.Key == discriminator)
-                return type.Type;
+            if (attribute.Key == discriminator)
+                return attribute.Type;
         }
 
         return objectType;
@@ -101,10 +101,10 @@ internal class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
 
     private string GetSubtypeDiscriminator(System.Type objectType)
     {
-        foreach (var type in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
+        foreach (var attribute in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
         {
-            if (type.Type == objectType)
-                return type.Key;
+            if (attribute.Type == objectType)
+                return attribute.Key;
         }
 
         return objectType.Name;

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/JsonInheritanceConverter.liquid
@@ -28,7 +28,7 @@ internal class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
             _isWriting = true;
 
             var jObject = Newtonsoft.Json.Linq.JObject.FromObject(value, serializer);
-            jObject.AddFirst(new Newtonsoft.Json.Linq.JProperty(_discriminator, value.GetType().Name));
+            jObject.AddFirst(new Newtonsoft.Json.Linq.JProperty(_discriminator, GetSubtypeDiscriminator(value.GetType())));
             writer.WriteToken(jObject.CreateReader());
         }
         finally
@@ -97,5 +97,16 @@ internal class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
         }
 
         return objectType;
+    }
+
+    private string GetSubtypeDiscriminator(System.Type objectType)
+    {
+        foreach (var type in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
+        {
+            if (type.Type == objectType)
+                return type.Key;
+        }
+
+        return objectType.Name;
     }
 }

--- a/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
+++ b/src/NJsonSchema.CodeGeneration.Tests/InheritanceSerializationTests.cs
@@ -10,6 +10,10 @@ using NJsonSchema.CodeGeneration.TypeScript;
 using NJsonSchema.Converters;
 using Xunit;
 
+using System.IO;
+using System.Reflection;
+using System.CodeDom.Compiler;
+
 namespace NJsonSchema.CodeGeneration.Tests
 {
     public class Container
@@ -151,7 +155,7 @@ namespace NJsonSchema.CodeGeneration.Tests
         public class C : B
         {
         }
-        
+
         [Fact]
         public async Task When_dates_are_converted_then_JsonInheritanceConverter_should_inherit_settings()
         {
@@ -258,6 +262,77 @@ namespace NJsonSchema.CodeGeneration.Tests
             // discriminator is assign for serialization
             Assert.Contains("this._discriminator = \"Animal\"", code);
             Assert.Contains("this._discriminator = \"Dog\"", code);
+        }
+
+        [Fact]
+        public async Task Subtypes_are_serialized_with_correct_discriminator()
+        {
+            //// Arrange
+            var json = await JsonSchema4.FromJsonAsync(@"{""title"":""foo"",""type"":""object"",""discriminator"":""discriminator"",""properties"":{""discriminator"":{""type"":""string""}},""definitions"":{""bar"":{""type"":""object"",""allOf"":[{""$ref"":""#""}]}}}");
+            var data = json.ToJson();
+
+            var generator = new CSharpGenerator(json, new CSharpGeneratorSettings() { ClassStyle = CSharpClassStyle.Poco, Namespace = "foo" });
+
+            //// Act
+            var code = generator.GenerateFile();
+
+            var assembly = Compile(code);
+            var type = assembly.GetType("foo.Foo");
+            if (type == null)
+            {
+                throw new Exception("Foo not found in " + String.Join(", ", assembly.GetTypes().Select(t => t.Name)));
+            }
+
+            var bar = JsonConvert.DeserializeObject(@"{""discriminator"":""bar""}", type);
+
+            //// Assert
+            Assert.Contains(@"""bar""", JsonConvert.SerializeObject(bar));
+        }
+
+        private Assembly Compile(string code)
+        {
+#if NETCOREAPP2_0
+            var coreDir = Directory.GetParent(typeof(Enumerable).GetTypeInfo().Assembly.Location);
+
+            Microsoft.CodeAnalysis.CSharp.CSharpCompilation compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create("assemblyName")
+             .WithOptions(new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary))
+             .AddReferences(Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                            Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(JsonConvert).Assembly.Location),
+                            Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(GeneratedCodeAttribute).Assembly.Location),
+                            Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Runtime.dll"),
+                            Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Dynamic.Runtime.dll"),
+                            Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.IO.dll"),
+                            Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Linq.Expressions.dll"),
+                            Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(coreDir.FullName + Path.DirectorySeparatorChar + "System.Runtime.Extensions.dll"))
+             .AddSyntaxTrees(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(code));
+
+            using (var stream = new MemoryStream())
+            {
+                var result = compilation.Emit(stream);
+
+                if (!result.Success)
+                {
+                    throw new Exception(String.Join(", ", result.Diagnostics
+                        .Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+                        .Select(d => d.Location.GetLineSpan().StartLinePosition + " - " + d.GetMessage())) + "\n" + code);
+                }
+
+                return Assembly.Load(stream.GetBuffer());
+            }
+#endif
+
+#if NET451
+            var provider = new CSharpCodeProvider();
+            var parameters = new CompilerParameters()
+            {
+                GenerateInMemory = true,
+                GenerateExecutable = false
+            };
+            var compilationResult = provider.CompileAssemblyFromSource(parameters, code);
+            Assert.False(compilationResult.Errors.HasErrors, String.Join(", ", compilationResult.Errors));
+
+            return compilationResult.CompiledAssembly;
+#endif
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.Tests/NJsonSchema.CodeGeneration.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" Condition="'$(TargetFramework)' == 'netcoreapp2.0'"/>
 
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 


### PR DESCRIPTION
This ensures that the key that is written matches the key that was read.