### PR TITLE
Convert to IEnumerable<Type> instead of Type[] in the KnownTypeAttribute(String) handling

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -574,7 +574,7 @@ namespace NJsonSchema.Generation
                     var methodInfo = type.GetRuntimeMethod((string)attribute.MethodName, new Type[0]);
                     if (methodInfo != null)
                     {
-                        var knownTypes = methodInfo.Invoke(null, null) as Type[];
+                        var knownTypes = methodInfo.Invoke(null, null) as IEnumerable<Type>;
                         if (knownTypes != null)
                         {
                             foreach (var knownType in knownTypes)


### PR DESCRIPTION
The `KnownTypeAttribute(String)` documentation says that the method returns a `IEnumerable<T>` of `Type` objects, so `Type[]` is too strict here. The implementation of `System.Runtime.Serialization.DataContract` confirms this, it verifies that the method returns a `IEnumerable<Type>`.