### PR TITLE
implements Record class style

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,10 @@
+; What is EditorConfig? http://editorconfig.org/
+
+root = true
+
+; general settings
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+insert_final_newline = false

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -1401,5 +1401,58 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.DoesNotContain(@"class DateFormatConverter", code);
             Assert.DoesNotContain(@"[Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]", code);
         }
+
+        [Fact]
+        public async Task When_record_no_setter_in_class_and_constructor_provided()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<Address>();
+            var data = schema.ToJson();
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Record
+            });
+
+            //// Act
+            var output = generator.GenerateFile("Address");
+
+            //// Assert
+            Assert.Contains      (@"public string Street { get; }",      output);
+            Assert.DoesNotContain(@"public string Street { get; set; }", output);
+
+            Assert.Contains("public Address(string Street, string City)", output);
+            Assert.Contains("public Address(string Street, string City)", output);
+        }
+
+        public abstract class AbstractAddress
+        {
+            [JsonProperty("city")]
+            [DefaultValue("Innsmouth")]
+            public string City   { get; set; }
+
+            [JsonProperty("street")]
+            public string Street { get; set; }
+        }
+
+        [Fact]
+        public async Task When_class_is_abstract_constructor_is_protected_for_record()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<AbstractAddress>();
+            var data = schema.ToJson();
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Record,
+            });
+
+            //// Act
+            var output = generator.GenerateFile("AbstractAddress");
+
+            //// Assert
+            Assert.Contains      (@"public string Street { get; }",      output);
+            Assert.DoesNotContain(@"public string Street { get; set; }", output);
+
+            Assert.Contains("protected AbstractAddress(string street, string city = \"Innsmouth\")", output);
+        }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -1420,18 +1420,18 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains      (@"public string Street { get; }",      output);
             Assert.DoesNotContain(@"public string Street { get; set; }", output);
 
-            Assert.Contains("public Address(string Street, string City)", output);
-            Assert.Contains("public Address(string Street, string City)", output);
+            Assert.Contains("public Address(string street, string city)", output);
+            Assert.Contains("public Address(string street, string city)", output);
         }
 
         public abstract class AbstractAddress
         {
             [JsonProperty("city")]
             [DefaultValue("Innsmouth")]
-            public string City   { get; set; }
+            public string CityName   { get; set; }
 
-            [JsonProperty("street")]
-            public string Street { get; set; }
+            [JsonProperty("streetName")]
+            public string StreetName { get; set; }
         }
 
         [Fact]
@@ -1449,10 +1449,13 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var output = generator.GenerateFile("AbstractAddress");
 
             //// Assert
-            Assert.Contains      (@"public string Street { get; }",      output);
-            Assert.DoesNotContain(@"public string Street { get; set; }", output);
+            Assert.Contains      (@"public string StreetName { get; }",      output);
+            Assert.DoesNotContain(@"public string StreetName { get; set; }", output);
+            
+            Assert.Contains      (@"public string City { get; }",      output);
+            Assert.DoesNotContain(@"public string City { get; set; }", output);
 
-            Assert.Contains("protected AbstractAddress(string street, string city = \"Innsmouth\")", output);
+            Assert.Contains("protected AbstractAddress(string streetName, string city = \"Innsmouth\")", output);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpClassStyle.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpClassStyle.cs
@@ -20,6 +20,9 @@ namespace NJsonSchema.CodeGeneration.CSharp
         Inpc,
 
         /// <summary>Generates classes implementing the Prism base class.</summary>
-        Prism
+        Prism,
+
+        /// <summary>Generates Records - read only POCOs (Plain Old C# Objects).</summary>
+        Record
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -70,6 +70,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets a value indicating whether the class style is Prism.</summary>
         public bool RenderPrism => _settings.ClassStyle == CSharpClassStyle.Prism;
 
+        /// <summary>Gets a value indicating whether the class style is Record.</summary>
+        public bool RenderRecord => _settings.ClassStyle == CSharpClassStyle.Record;
+
         /// <summary>Gets a value indicating whether to render ToJson() and FromJson() methods.</summary>
         public bool GenerateJsonMethods => _settings.GenerateJsonMethods;
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Templates\Class.Body.liquid" />
+    <None Remove="Templates\Class.Constructor.Record.liquid" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Templates\Class.Annotations.liquid">
@@ -31,6 +32,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Templates\Class.Body.liquid" />
     <EmbeddedResource Include="Templates\Class.Constructor.liquid" />
+    <EmbeddedResource Include="Templates\Class.Constructor.Record.liquid" />
     <EmbeddedResource Include="Templates\Class.FromJson.liquid">
       <CustomToolNamespace>
       </CustomToolNamespace>

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -1,0 +1,9 @@
+﻿{% assign skipComma = true -%}
+{% assign sortedProperties = (Properties | sort: "HasDefaultValue") -%}
+[Newtonsoft.Json.JsonConstructor]
+{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name }}{% if property.HasDefaultValue == true %} = {{ property.DefaultValue }}{% endif %}{% endfor -%})
+{
+{% for property in Properties -%}
+    this.{{property.PropertyName}} = @{{property.Name}};
+{% endfor -%}
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -4,6 +4,6 @@
 {% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name | lowercamelcase }}{% if property.HasDefaultValue == true %} = {{ property.DefaultValue }}{% endif %}{% endfor -%})
 {
 {% for property in Properties -%}
-    this.{{property.PropertyName}} = @{{property.Name}};
+    {{property.PropertyName}} = @{{property.Name | lowercamelcase}};
 {% endfor -%}
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -1,7 +1,7 @@
 ﻿{% assign skipComma = true -%}
 {% assign sortedProperties = (Properties | sort: "HasDefaultValue") -%}
 [Newtonsoft.Json.JsonConstructor]
-{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name }}{% if property.HasDefaultValue == true %} = {{ property.DefaultValue }}{% endif %}{% endfor -%})
+{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name | lowercamelcase }}{% if property.HasDefaultValue == true %} = {{ property.DefaultValue }}{% endif %}{% endfor -%})
 {
 {% for property in Properties -%}
     this.{{property.PropertyName}} = @{{property.Name}};

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -18,6 +18,10 @@
 
 {% endif -%}
     {% template Class.Constructor %}
+{% if RenderRecord == true -%}
+    {% template Class.Constructor.Record %}
+
+{% endif -%}
 {% for property in Properties -%}
 {%   if property.HasDescription -%}
     /// <summary>{{ property.Description | csharpdocs }}</summary>
@@ -42,7 +46,7 @@
     [Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]
 {%   endif -%}
     {% template Class.Property.Annotations %}
-    public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter %}set; {% endif %}}{% if property.HasDefaultValue %} = {{ property.DefaultValue }};{% endif %}
+    public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% endif %}}{% if property.HasDefaultValue %} = {{ property.DefaultValue }};{% endif %}
 {% else %}
     {
         get { return {{ property.FieldName }}; }

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -185,6 +185,11 @@ namespace NJsonSchema.CodeGeneration
             {
                 return ConversionUtilities.ConvertToLowerCamelCase(input, firstCharacterMustBeAlpha);
             }
+
+            public static string Uppercamelcase(Context context, string input, bool firstCharacterMustBeAlpha = true)
+            {
+                return ConversionUtilities.ConvertToUpperCamelCase(input, firstCharacterMustBeAlpha);
+            }
         }
 
         internal class TemplateTag : Tag

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -180,6 +180,11 @@ namespace NJsonSchema.CodeGeneration
             {
                 return ConversionUtilities.Tab(input, tabCount);
             }
+
+            public static string Lowercamelcase(Context context, string input, bool firstCharacterMustBeAlpha = true)
+            {
+                return ConversionUtilities.ConvertToLowerCamelCase(input, firstCharacterMustBeAlpha);
+            }
         }
 
         internal class TemplateTag : Tag

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -22,7 +22,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DotLiquid" Version="2.0.200" />
+    <PackageReference Include="DotLiquid" Version="2.0.254" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">


### PR DESCRIPTION
I'v failed to implement [Record](https://github.com/RSuter/NSwag/issues/1207) class style using only extension templates because setters should be private and this needs to edit `Class.liquid` 

So:
* new Record class style is implemented
* DotLiquid updated (previous version does not support `sort` array filter)
* .editorconfig added for managing indents 