### PR TITLE
Blank line before class body implementation

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -83,5 +83,6 @@
 
     {% template Class.Inpc %}
 {% endif -%}
+
     {% template Class.Body %}
 }


### PR DESCRIPTION
If you implement the body, there is no space between the last method and the body, and is a little uggly.