### PR TITLE
 Resolve another instance of Contract Resolver not being cached. 

### DIFF
--- a/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
+++ b/src/NJsonSchema.Benchmark/NJsonSchema.Benchmark.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Schema.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NBench" Version="1.0.4" />
+    <PackageReference Include="Pro.NBench.xUnit" Version="1.0.4" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NJsonSchema.Benchmark/Program.cs
+++ b/src/NJsonSchema.Benchmark/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace NJsonSchema.Benchmark
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<SerializationPerformance>();
+        }
+    }
+}

--- a/src/NJsonSchema.Benchmark/Schema.json
+++ b/src/NJsonSchema.Benchmark/Schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "some_property": {
+      "description": "Example property",
+      "type": "string",
+      "maxLength": 64
+    }
+  }
+}

--- a/src/NJsonSchema.Benchmark/SerializationPerformance.cs
+++ b/src/NJsonSchema.Benchmark/SerializationPerformance.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+
+namespace NJsonSchema.Benchmark
+{
+    public class SerializationPerformance
+    {
+        private readonly string _json;
+        private readonly JsonSchema4 _schema;
+
+        public SerializationPerformance()
+        {
+            // We need to embed the resource as BenchmarkDotNet
+            // will rebuild this project.
+            var executingAssembly = Assembly.GetExecutingAssembly();
+
+            using (var reader = new StreamReader(
+                executingAssembly.GetManifestResourceStream(
+                    executingAssembly.GetName().Name + ".Schema.json")))
+            {
+                _json = reader.ReadToEnd();
+            }
+
+            _schema = JsonSchema4.FromJsonAsync(_json).Result;
+        }
+
+        [Benchmark]
+        public string ToJson()
+        {
+            return _schema.ToJson();
+        }
+
+        [Benchmark]
+        public JsonSchema4 FromJson()
+        {
+            return JsonSchema4.FromJsonAsync(_json).Result;
+        }
+    }
+}

--- a/src/NJsonSchema.Benchmark/SerializationPerformanceTests.cs
+++ b/src/NJsonSchema.Benchmark/SerializationPerformanceTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Diagnostics;
+using NBench;
+using Pro.NBench.xUnit.XunitExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace NJsonSchema.Benchmark
+{
+    public class SerializationPerformanceTests
+    {
+        private readonly SerializationPerformance _serializationPerformance = new SerializationPerformance();
+        private Counter _counter;
+
+        public SerializationPerformanceTests(ITestOutputHelper output)
+        {
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(new XunitTraceListener(output));
+        }
+
+        [PerfSetup]
+        #pragma warning disable xUnit1013 // Public method should be marked as test
+        public void Setup(BenchmarkContext context)
+        #pragma warning restore xUnit1013 // Public method should be marked as test
+        {
+            _counter = context.GetCounter("Iterations");
+        }
+
+        /// <summary>
+        /// Ensure that we can serialise at least 200 times per second (5ms).
+        /// </summary>
+        [NBenchFact]
+        [PerfBenchmark(
+            Description = "Ensure serialization doesn't take too long",
+            NumberOfIterations = 3,
+            RunTimeMilliseconds = 1000,
+            RunMode = RunMode.Throughput,
+            TestMode = TestMode.Test)]
+        [CounterThroughputAssertion("Iterations", MustBe.GreaterThan, 200)]
+        public void ToJson()
+        {
+            _serializationPerformance.ToJson();
+            _counter.Increment();
+        }
+
+        /// <summary>
+        /// Ensure that we can deserialise at least 200 times per second (5ms).
+        /// </summary>
+        [NBenchFact]
+        [PerfBenchmark(
+            Description = "Ensure deserialization doesn't take too long",
+            NumberOfIterations = 3,
+            RunTimeMilliseconds = 1000,
+            RunMode = RunMode.Throughput,
+            TestMode = TestMode.Test)]
+        [CounterThroughputAssertion("Iterations", MustBe.GreaterThan, 200)]
+        public void FromJson()
+        {
+            _serializationPerformance.FromJson();
+            _counter.Increment();
+        }
+    }
+}

--- a/src/NJsonSchema.sln
+++ b/src/NJsonSchema.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NJsonSchema.Yaml", "NJsonSc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NJsonSchema.Demo.Performance", "NJsonSchema.Demo.Performance\NJsonSchema.Demo.Performance.csproj", "{75B834E0-1F0D-4BC2-911D-5CF079BCE73B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NJsonSchema.Benchmark", "NJsonSchema.Benchmark\NJsonSchema.Benchmark.csproj", "{E59CE32B-181F-4AAE-BF62-772AEEFC3177}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -191,6 +193,22 @@ Global
 		{75B834E0-1F0D-4BC2-911D-5CF079BCE73B}.Release|x64.Build.0 = Release|Any CPU
 		{75B834E0-1F0D-4BC2-911D-5CF079BCE73B}.Release|x86.ActiveCfg = Release|Any CPU
 		{75B834E0-1F0D-4BC2-911D-5CF079BCE73B}.Release|x86.Build.0 = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|ARM.Build.0 = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|x64.Build.0 = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Debug|x86.Build.0 = Debug|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|ARM.ActiveCfg = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|ARM.Build.0 = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|x64.ActiveCfg = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|x64.Build.0 = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|x86.ActiveCfg = Release|Any CPU
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -202,6 +220,7 @@ Global
 		{974ED050-4A34-4513-8048-139B1AF1A95D} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
 		{E767A007-6007-4898-B80A-FE4ACBF2C588} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
 		{75B834E0-1F0D-4BC2-911D-5CF079BCE73B} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
+		{E59CE32B-181F-4AAE-BF62-772AEEFC3177} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9D5EDC80-5611-493B-804B-8B364816952B}

--- a/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
+++ b/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
@@ -91,7 +91,7 @@ namespace NJsonSchema.Infrastructure
                     referenceResolver.AddDocumentReference(documentPath, referenceSchema);
             }
 
-            await JsonSchemaReferenceUtilities.UpdateSchemaReferencesAsync(schema, referenceResolver).ConfigureAwait(false);
+            await JsonSchemaReferenceUtilities.UpdateSchemaReferencesAsync(schema, referenceResolver, contractResolver).ConfigureAwait(false);
             return schema;
         }
     }

--- a/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
+++ b/src/NJsonSchema/JsonSchemaReferenceUtilities.cs
@@ -19,13 +19,21 @@ namespace NJsonSchema
     /// <summary>Provides utilities to resolve and set JSON schema references.</summary>
     public static class JsonSchemaReferenceUtilities
     {
-        /// <summary>Updates all <see cref="IJsonReferenceBase.Reference"/> properties from the 
+        /// <summary>Updates all <see cref="IJsonReferenceBase.Reference"/> properties from the
         /// available <see cref="IJsonReferenceBase.Reference"/> properties.</summary>
         /// <param name="referenceResolver">The JSON document resolver.</param>
         /// <param name="rootObject">The root object.</param>
-        public static async Task UpdateSchemaReferencesAsync(object rootObject, JsonReferenceResolver referenceResolver)
+        public static Task UpdateSchemaReferencesAsync(object rootObject, JsonReferenceResolver referenceResolver) =>
+            UpdateSchemaReferencesAsync(rootObject, referenceResolver, new DefaultContractResolver());
+
+        /// <summary>Updates all <see cref="IJsonReferenceBase.Reference"/> properties from the
+        /// available <see cref="IJsonReferenceBase.Reference"/> properties.</summary>
+        /// <param name="referenceResolver">The JSON document resolver.</param>
+        /// <param name="rootObject">The root object.</param>
+        /// <param name="contractResolver">The contract resolver.</param>
+        public static async Task UpdateSchemaReferencesAsync(object rootObject, JsonReferenceResolver referenceResolver, IContractResolver contractResolver)
         {
-            var updater = new JsonReferenceUpdater(rootObject, referenceResolver);
+            var updater = new JsonReferenceUpdater(rootObject, referenceResolver, contractResolver);
             await updater.VisitAsync(rootObject).ConfigureAwait(false);
         }
 
@@ -78,7 +86,8 @@ namespace NJsonSchema
             private readonly JsonReferenceResolver _referenceResolver;
             private bool _replaceRefsRound;
 
-            public JsonReferenceUpdater(object rootObject, JsonReferenceResolver referenceResolver)
+            public JsonReferenceUpdater(object rootObject, JsonReferenceResolver referenceResolver, IContractResolver contractResolver)
+                : base(contractResolver)
             {
                 _rootObject = rootObject;
                 _referenceResolver = referenceResolver;


### PR DESCRIPTION
Also added benchmarking for JSON serialization.

Using `BenchmarkDotNet` the `NJsonSchema.Benchmark` project can be run to find out the performance of serialization and deserialization.

`NBench` tests are also integrated and should be runnable as normal `xUnit` tests.