### PR TITLE
CS records

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -1588,10 +1588,10 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Contains("protected AbstractAddress(string city, string streetName)", output);
 
             Assert.Contains("public PostAddress(string city, int houseNumber, string streetName, string zip)", output);
-            Assert.Contains(":base(city, streetName)", output);
+            Assert.Contains(": base(city, streetName)", output);
 
             Assert.Contains("public PersonAddress(string addressee, string city, int houseNumber, string streetName, string zip)", output);
-            Assert.Contains(":base(city, houseNumber, streetName, zip)", output);
+            Assert.Contains(": base(city, houseNumber, streetName, zip)", output);
 
             AssertCompile(output);
         }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -12,6 +12,9 @@ using NJsonSchema.CodeGeneration.CSharp;
 using NJsonSchema.Generation;
 using Xunit;
 using NJsonSchema.Annotations;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace NJsonSchema.CodeGeneration.Tests.CSharp
 {
@@ -35,6 +38,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public System.Collections.ObjectModel.ObservableCollection<object> EmptySchema { get; set; } = ", output);
+         
+            AssertCompile(output);
         }
 
         class CustomPropertyNameGenerator : IPropertyNameGenerator
@@ -120,6 +125,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains(@"public string MyCustomLastName", output);
             Assert.Contains(@"public partial class MyCustomTypeTeacher", output);
             Assert.Contains(@"public partial class MyCustomTypePerson", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -166,6 +173,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public System.Collections.ObjectModel.ObservableCollection<PRef>", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -180,6 +189,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains("namespace MyNamespace", output);
             Assert.Contains("Dictionary<string, int>", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -194,6 +205,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("{ get; set; }", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -208,6 +221,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains(@"[Newtonsoft.Json.JsonProperty(""lastName""", output);
             Assert.Contains(@"public string LastName", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -223,6 +238,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains(@"public System.TimeSpan TimeSpan", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -236,6 +253,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains(@"class Teacher : Person, ", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -251,6 +270,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains(@"/// <summary>EnumDesc.</summary>", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -266,6 +287,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains(@"/// <summary>ClassDesc.</summary>", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -281,6 +304,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains(@"/// <summary>PropertyDesc.</summary>", output);
+
+            AssertCompile(output);
         }
 
         public class File
@@ -300,6 +325,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             // Assert
             Assert.Contains("public byte[] Content", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -315,6 +342,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             // Assert
             Assert.Contains("public byte[] Content", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -335,6 +364,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             // Assert
             Assert.Contains(@"[Newtonsoft.Json.JsonProperty(""foo-bar"", ", output);
             Assert.Contains(@"public string FooBar", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -349,6 +380,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain(@"class  :", output);
+
+            AssertCompile(output);
         }
 
         private static async Task<CSharpGenerator> CreateGeneratorAsync()
@@ -394,6 +427,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public object Foo { get; set; }", code);
+
+            AssertCompile(code);
         }
 
         public enum ConstructionCode
@@ -428,6 +463,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public ConstructionCode ConstructionCode { get; set; } = Foo.ConstructionCode.NON_CBST;", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -447,6 +484,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public ConstructionCode ConstructionCode { get; set; } = Foo.ConstructionCode.NON_CBST;", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -487,6 +526,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public MyClassConstructionCode ConstructionCode { get; set; } = Foo.MyClassConstructionCode.JOIST_MAS;", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -510,6 +551,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains("[Newtonsoft.Json.JsonProperty(\"Foo\", Required = Newtonsoft.Json.Required.DisallowNull", code);
             Assert.Contains("public string Foo1 { get; set; }", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -538,6 +581,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public System.Collections.Generic.Dictionary<string, string> Dict { get; set; } = new System.Collections.Generic.Dictionary<string, string>();", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -557,6 +602,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public partial class FooOfBarOfInner", code);
+
+            AssertCompile(code);
         }
 
         [JsonObject(MemberSerialization.OptIn)]
@@ -616,6 +663,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
     
         [Newtonsoft.Json.JsonProperty(""Age"", Required = Newtonsoft.Json.Required.AllowNull)]
         public int? Age { get; set; }".Replace("\r", string.Empty), code.Replace("\r", string.Empty));
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -660,6 +709,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains("public System.Collections.ObjectModel.ObservableCollection<string> A { get; set; } = new System.Collections.ObjectModel.ObservableCollection<string>();", code);
             Assert.DoesNotContain("public System.Collections.ObjectModel.ObservableCollection<string> B { get; set; } = new System.Collections.ObjectModel.ObservableCollection<string>();", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -704,6 +755,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains("public System.Collections.Generic.Dictionary<string, string> A { get; set; } = new System.Collections.Generic.Dictionary<string, string>();", code);
             Assert.DoesNotContain("public System.Collections.Generic.Dictionary<string, string> B { get; set; } = new System.Collections.Generic.Dictionary<string, string>();", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -756,6 +809,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains("public A A { get; set; } = new A();", code);
             Assert.DoesNotContain("public B B { get; set; } = new B();", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -789,6 +844,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public object Foo { get; set; }", code);
+
+            AssertCompile(code);
         }
 
         public class ObsClass
@@ -810,7 +867,9 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("ObservableCollection<string>", output);
-        }
+        
+            AssertCompile(output);
+}
 
         [Fact]
         public async Task When_enum_has_special_chars_then_they_should_be_converted()
@@ -827,6 +886,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("Application_vnd_msExcel = 1,", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -850,6 +911,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public string OdataContext", output);
+
+            AssertCompile(output);
         }
 
         [Fact]
@@ -878,6 +941,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.Range(1, int.MaxValue)]", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -906,6 +971,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.Range(int.MinValue, 10)]", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -935,6 +1002,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.Range(1, 10)]", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -963,6 +1032,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain("System.ComponentModel.DataAnnotations.Range", code);
+
+            AssertCompile(code);
         }
 
         [Fact]
@@ -991,6 +1062,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 10)]", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1019,6 +1092,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(20)]", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1048,6 +1123,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(20, MinimumLength = 10)]", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1077,6 +1154,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain("System.ComponentModel.DataAnnotations.StringLength", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1105,6 +1184,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains(@"[System.ComponentModel.DataAnnotations.RegularExpression(@""^[a-zA-Z''-'\s]{1,40}$"")]", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1133,6 +1214,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain(@"System.ComponentModel.DataAnnotations.RegularExpression", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1173,6 +1256,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain(@"System.ComponentModel.DataAnnotations", code);
+        
+            AssertCompile(code);
         }
 
         public class MyByteTest
@@ -1193,6 +1278,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public byte? Cell { get; set; }", code);
+        
+            AssertCompile(code);
         }
 
         public class MyRequiredNullableTest
@@ -1214,6 +1301,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public int Foo { get; set; }", code);
+                
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1244,7 +1333,9 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains(@"class DateFormatConverter", code);
             Assert.Contains(@"[Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]", code);
-	    }
+        
+            AssertCompile(code);
+        }
 
         [Fact]
         public async Task When_no_typeNameHint_is_available_then_title_is_used_as_class_name()
@@ -1282,6 +1373,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain("Anonymous", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1340,6 +1433,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.DoesNotContain("System.Linq.Enumerable+SelectIListIterator", code);
             Assert.Contains("ObservableCollection<System.Tuple<int, int>>", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1370,6 +1465,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains(@"class DateFormatConverter", code);
             Assert.Contains(@"[Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1400,6 +1497,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.DoesNotContain(@"class DateFormatConverter", code);
             Assert.DoesNotContain(@"[Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]", code);
+        
+            AssertCompile(code);
         }
 
         [Fact]
@@ -1410,7 +1509,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var data = schema.ToJson();
             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
             {
-                ClassStyle = CSharpClassStyle.Record
+                ClassStyle = CSharpClassStyle.Record,
+                Namespace = "Tests"
             });
 
             //// Act
@@ -1422,6 +1522,8 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             Assert.Contains("public Address(string street, string city)", output);
             Assert.Contains("public Address(string street, string city)", output);
+        
+            AssertCompile(output);
         }
 
         public abstract class AbstractAddress
@@ -1434,6 +1536,18 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             public string StreetName { get; set; }
         }
 
+        public class PostAddress : AbstractAddress
+        {
+            public string Zip         { get; set; }
+            public int    HouseNumber { get; set; }
+        }
+
+        public class PersonAddress : PostAddress
+        {
+            public string Addressee { get; set; }
+        }
+
+
         [Fact]
         public async Task When_class_is_abstract_constructor_is_protected_for_record()
         {
@@ -1443,6 +1557,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
             {
                 ClassStyle = CSharpClassStyle.Record,
+                Namespace = "Tests"
             });
 
             //// Act
@@ -1453,9 +1568,52 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.DoesNotContain(@"public string StreetName { get; set; }", output);
             
             Assert.Contains      (@"public string City { get; }",      output);
+            Assert.DoesNotContain(@"public string City { get; } =",    output);
             Assert.DoesNotContain(@"public string City { get; set; }", output);
 
             Assert.Contains("protected AbstractAddress(string streetName, string city = \"Innsmouth\")", output);
+
+            AssertCompile(output);
+        }
+
+        [Fact]
+        public async Task When_record_has_inheritance()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<PersonAddress>();
+            var data = schema.ToJson();
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Record,
+                Namespace = "Tests"
+            });
+
+            //// Act
+            var output = generator.GenerateFile("PersonAddress");
+
+            Assert.Contains("protected AbstractAddress(string streetName, string city = \"Innsmouth\")", output);
+            
+            Assert.Contains("public PostAddress(string zip, int houseNumber, string streetName, string city = \"Innsmouth\")", output);
+            Assert.Contains(":base(streetName, city)", output);
+
+            Assert.Contains("public PersonAddress(string addressee, string zip, int houseNumber, string streetName, string city = \"Innsmouth\")", output);
+            Assert.Contains(":base(zip, houseNumber, streetName, city)", output);
+
+            AssertCompile(output);
+        }
+
+        private static void AssertCompile(string code)
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(code);
+            var errors = syntaxTree
+                .GetDiagnostics()
+                .Where(_ => _.Severity == DiagnosticSeverity.Error);
+            
+            var sb = new StringBuilder();
+            foreach(var e in errors)
+                sb.AppendLine($"{e.Id} at {e.Location}: {e.GetMessage()}");
+
+            Assert.Empty(sb.ToString());
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -5,18 +5,17 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using NJsonSchema.CodeGeneration.CSharp;
-using NJsonSchema.Generation;
-using Xunit;
-using NJsonSchema.Annotations;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NJsonSchema.Annotations;
+using NJsonSchema.Generation;
+using Xunit;
 
-namespace NJsonSchema.CodeGeneration.Tests.CSharp
+namespace NJsonSchema.CodeGeneration.CSharp.Tests
 {
     public class CSharpGeneratorTests
     {
@@ -38,7 +37,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public System.Collections.ObjectModel.ObservableCollection<object> EmptySchema { get; set; } = ", output);
-         
+
             AssertCompile(output);
         }
 
@@ -867,9 +866,9 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("ObservableCollection<string>", output);
-        
+
             AssertCompile(output);
-}
+        }
 
         [Fact]
         public async Task When_enum_has_special_chars_then_they_should_be_converted()
@@ -1062,7 +1061,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 10)]", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1092,7 +1091,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(20)]", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1123,7 +1122,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("[System.ComponentModel.DataAnnotations.StringLength(20, MinimumLength = 10)]", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1154,7 +1153,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain("System.ComponentModel.DataAnnotations.StringLength", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1184,7 +1183,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains(@"[System.ComponentModel.DataAnnotations.RegularExpression(@""^[a-zA-Z''-'\s]{1,40}$"")]", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1214,7 +1213,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain(@"System.ComponentModel.DataAnnotations.RegularExpression", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1256,7 +1255,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain(@"System.ComponentModel.DataAnnotations", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1278,7 +1277,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public byte? Cell { get; set; }", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1301,7 +1300,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.Contains("public int Foo { get; set; }", code);
-                
+
             AssertCompile(code);
         }
 
@@ -1333,7 +1332,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains(@"class DateFormatConverter", code);
             Assert.Contains(@"[Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1373,7 +1372,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
             //// Assert
             Assert.DoesNotContain("Anonymous", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1433,7 +1432,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.DoesNotContain("System.Linq.Enumerable+SelectIListIterator", code);
             Assert.Contains("ObservableCollection<System.Tuple<int, int>>", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1465,7 +1464,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.Contains(@"class DateFormatConverter", code);
             Assert.Contains(@"[Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1497,7 +1496,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Assert
             Assert.DoesNotContain(@"class DateFormatConverter", code);
             Assert.DoesNotContain(@"[Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]", code);
-        
+
             AssertCompile(code);
         }
 
@@ -1509,19 +1508,18 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var data = schema.ToJson();
             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
             {
-                ClassStyle = CSharpClassStyle.Record,
-                Namespace = "Tests"
+                ClassStyle = CSharpClassStyle.Record
             });
 
             //// Act
             var output = generator.GenerateFile("Address");
 
             //// Assert
-            Assert.Contains      (@"public string Street { get; }",      output);
+            Assert.Contains(@"public string Street { get; }", output);
             Assert.DoesNotContain(@"public string Street { get; set; }", output);
 
             Assert.Contains("public Address(string city, string street)", output);
-        
+
             AssertCompile(output);
         }
 
@@ -1529,7 +1527,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         {
             [JsonProperty("city")]
             [DefaultValue("Innsmouth")]
-            public string CityName   { get; set; }
+            public string CityName { get; set; }
 
             [JsonProperty("streetName")]
             public string StreetName { get; set; }
@@ -1537,15 +1535,14 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
 
         public class PostAddress : AbstractAddress
         {
-            public string Zip         { get; set; }
-            public int    HouseNumber { get; set; }
+            public string Zip { get; set; }
+            public int HouseNumber { get; set; }
         }
 
         public class PersonAddress : PostAddress
         {
             public string Addressee { get; set; }
         }
-
 
         [Fact]
         public async Task When_class_is_abstract_constructor_is_protected_for_record()
@@ -1555,19 +1552,18 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var data = schema.ToJson();
             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
             {
-                ClassStyle = CSharpClassStyle.Record,
-                Namespace = "Tests"
+                ClassStyle = CSharpClassStyle.Record
             });
 
             //// Act
             var output = generator.GenerateFile("AbstractAddress");
 
             //// Assert
-            Assert.Contains      (@"public string StreetName { get; }",      output);
+            Assert.Contains(@"public string StreetName { get; }", output);
             Assert.DoesNotContain(@"public string StreetName { get; set; }", output);
-            
-            Assert.Contains      (@"public string City { get; }",      output);
-            Assert.DoesNotContain(@"public string City { get; } =",    output);
+
+            Assert.Contains(@"public string City { get; }", output);
+            Assert.DoesNotContain(@"public string City { get; } =", output);
             Assert.DoesNotContain(@"public string City { get; set; }", output);
 
             Assert.Contains("protected AbstractAddress(string city, string streetName)", output);
@@ -1583,15 +1579,14 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var data = schema.ToJson();
             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
             {
-                ClassStyle = CSharpClassStyle.Record,
-                Namespace = "Tests"
+                ClassStyle = CSharpClassStyle.Record
             });
 
             //// Act
             var output = generator.GenerateFile("PersonAddress");
 
             Assert.Contains("protected AbstractAddress(string city, string streetName)", output);
-            
+
             Assert.Contains("public PostAddress(string city, int houseNumber, string streetName, string zip)", output);
             Assert.Contains(":base(city, streetName)", output);
 
@@ -1607,9 +1602,9 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var errors = syntaxTree
                 .GetDiagnostics()
                 .Where(_ => _.Severity == DiagnosticSeverity.Error);
-            
+
             var sb = new StringBuilder();
-            foreach(var e in errors)
+            foreach (var e in errors)
                 sb.AppendLine($"{e.Id} at {e.Location}: {e.GetMessage()}");
 
             Assert.Empty(sb.ToString());

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -1520,8 +1520,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains      (@"public string Street { get; }",      output);
             Assert.DoesNotContain(@"public string Street { get; set; }", output);
 
-            Assert.Contains("public Address(string street, string city)", output);
-            Assert.Contains("public Address(string street, string city)", output);
+            Assert.Contains("public Address(string city, string street)", output);
         
             AssertCompile(output);
         }
@@ -1571,7 +1570,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.DoesNotContain(@"public string City { get; } =",    output);
             Assert.DoesNotContain(@"public string City { get; set; }", output);
 
-            Assert.Contains("protected AbstractAddress(string streetName, string city = \"Innsmouth\")", output);
+            Assert.Contains("protected AbstractAddress(string city, string streetName)", output);
 
             AssertCompile(output);
         }
@@ -1591,13 +1590,13 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             //// Act
             var output = generator.GenerateFile("PersonAddress");
 
-            Assert.Contains("protected AbstractAddress(string streetName, string city = \"Innsmouth\")", output);
+            Assert.Contains("protected AbstractAddress(string city, string streetName)", output);
             
-            Assert.Contains("public PostAddress(string zip, int houseNumber, string streetName, string city = \"Innsmouth\")", output);
-            Assert.Contains(":base(streetName, city)", output);
+            Assert.Contains("public PostAddress(string city, int houseNumber, string streetName, string zip)", output);
+            Assert.Contains(":base(city, streetName)", output);
 
-            Assert.Contains("public PersonAddress(string addressee, string zip, int houseNumber, string streetName, string city = \"Innsmouth\")", output);
-            Assert.Contains(":base(zip, houseNumber, streetName, city)", output);
+            Assert.Contains("public PersonAddress(string addressee, string city, int houseNumber, string streetName, string zip)", output);
+            Assert.Contains(":base(city, houseNumber, streetName, zip)", output);
 
             AssertCompile(output);
         }

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
@@ -15,7 +15,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 
     <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
-    <Reference Condition="'$(TargetFramework)' == 'net451'" Include="System.ComponentModel.DataAnnotations"></Reference>
+    <Reference Condition="'$(TargetFramework)' == 'net461'" Include="System.ComponentModel.DataAnnotations"></Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/NJsonSchema.CodeGeneration.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
 
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -16,6 +16,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
         /// <summary>Initializes a new instance of the <see cref="CSharpGeneratorSettings"/> class.</summary>
         public CSharpGeneratorSettings()
         {
+            Namespace = "MyNamespace";
+
             DateType = "System.DateTime";
             DateTimeType = "System.DateTime";
             TimeType = "System.TimeSpan";
@@ -41,8 +43,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
             });
         }
 
-        /// <summary>Gets or sets the .NET namespace of the generated types. (default: System)</summary>
-        public string Namespace { get; set; } = "System";
+        /// <summary>Gets or sets the .NET namespace of the generated types (default: MyNamespace).</summary>
+        public string Namespace { get; set; }
 
         /// <summary>Gets or sets a value indicating whether a required property must be defined in JSON 
         /// (sets Required.Always when the property is required) (default: true).</summary>

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -40,8 +40,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
             });
         }
 
-        /// <summary>Gets or sets the .NET namespace of the generated types.</summary>
-        public string Namespace { get; set; }
+        /// <summary>Gets or sets the .NET namespace of the generated types. (default: System)</summary>
+        public string Namespace { get; set; } = "System";
 
         /// <summary>Gets or sets a value indicating whether a required property must be defined in JSON 
         /// (sets Required.Always when the property is required) (default: true).</summary>

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -37,7 +37,15 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
             Properties = _schema.ActualProperties.Values
                 .Where(p => !p.IsInheritanceDiscriminator)
                 .Select(property => new PropertyModel(this, property, _resolver, _settings))
-                .ToList();
+                .ToArray();
+
+            if (HasInheritance)
+            {
+                BaseClass = new ClassTemplateModel(BaseClassName, settings, resolver, schema.InheritedSchema, rootObject);
+                AllProperties = Properties.Concat(BaseClass.AllProperties).ToArray();
+            }
+            else
+                AllProperties = Properties;
         }
 
         /// <summary>Gets or sets the class name.</summary>
@@ -57,6 +65,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
 
         /// <summary>Gets the property models.</summary>
         public IEnumerable<PropertyModel> Properties { get; }
+
+        /// <summary>Gets the property models with inherited properties.</summary>
+        public IEnumerable<PropertyModel> AllProperties { get; }
 
         /// <summary>Gets a value indicating whether the class has description.</summary>
         public bool HasDescription => !(_schema is JsonProperty) && !string.IsNullOrEmpty(_schema.Description);
@@ -89,6 +100,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string BaseClassName => HasInheritance ? _resolver.Resolve(_schema.InheritedSchema, false, string.Empty)
                 .Replace(_settings.ArrayType + "<", _settings.ArrayBaseType + "<")
                 .Replace(_settings.DictionaryType + "<", _settings.DictionaryBaseType + "<") : null;
+
+        /// <summary>Base class model </summary>
+        public ClassTemplateModel BaseClass { get; }
 
         /// <summary>Gets a value indicating whether to use the DateFormatConverter.</summary>
         public bool UseDateFormatConverter => _settings.DateType.StartsWith("System.Date");

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/ClassTemplateModel.cs
@@ -102,7 +102,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                 .Replace(_settings.ArrayType + "<", _settings.ArrayBaseType + "<")
                 .Replace(_settings.DictionaryType + "<", _settings.DictionaryBaseType + "<") : null;
 
-        /// <summary>Base class model </summary>
+        /// <summary>Gets the base class model.</summary>
         public ClassTemplateModel BaseClass { get; }
 
         /// <summary>Gets a value indicating whether the class inherits from exception.</summary>

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -1,7 +1,19 @@
 ﻿{% assign skipComma = true -%}
-{% assign sortedProperties = (Properties | sort: "HasDefaultValue") -%}
+{% if HasInheritance %}
+{% assign parentProperties = BaseClass.AllProperties -%}
+{% else %}
+{% assign parentProperties = "" | empty -%}
+{% endif %}
+
+{% assign sortedProperties = AllProperties | sort: "HasDefaultValue" -%}
+{% assign sortedParentProperties = parentProperties | sort: "HasDefaultValue" -%}
+
 [Newtonsoft.Json.JsonConstructor]
 {% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name | lowercamelcase }}{% if property.HasDefaultValue == true %} = {{ property.DefaultValue }}{% endif %}{% endfor -%})
+{% assign skipComma = true -%}
+{% if HasInheritance -%}
+    :base({% for property in sortedParentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.Name | lowercamelcase }}{% endfor -%})
+{% endif -%}
 {
 {% for property in Properties -%}
     {{property.PropertyName}} = @{{property.Name | lowercamelcase}};

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -12,7 +12,7 @@
 {% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name | lowercamelcase }}{% endfor -%})
 {% assign skipComma = true -%}
 {% if HasInheritance -%}
-    :base({% for property in sortedParentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.Name | lowercamelcase }}{% endfor -%})
+    : base({% for property in sortedParentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.Name | lowercamelcase }}{% endfor -%})
 {% endif -%}
 {
 {% for property in Properties -%}

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.Constructor.Record.liquid
@@ -5,11 +5,11 @@
 {% assign parentProperties = "" | empty -%}
 {% endif %}
 
-{% assign sortedProperties = AllProperties | sort: "HasDefaultValue" -%}
-{% assign sortedParentProperties = parentProperties | sort: "HasDefaultValue" -%}
+{% assign sortedProperties = AllProperties | sort: "Name" -%}
+{% assign sortedParentProperties = parentProperties | sort: "Name" -%}
 
 [Newtonsoft.Json.JsonConstructor]
-{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name | lowercamelcase }}{% if property.HasDefaultValue == true %} = {{ property.DefaultValue }}{% endif %}{% endfor -%})
+{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in sortedProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} {{ property.Name | lowercamelcase }}{% endfor -%})
 {% assign skipComma = true -%}
 {% if HasInheritance -%}
     :base({% for property in sortedParentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.Name | lowercamelcase }}{% endfor -%})

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -46,7 +46,7 @@
     [Newtonsoft.Json.JsonConverter(typeof(DateFormatConverter))]
 {%   endif -%}
     {% template Class.Property.Annotations %}
-    public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% endif %}}{% if property.HasDefaultValue %} = {{ property.DefaultValue }};{% endif %}
+    public {{ property.Type }} {{ property.PropertyName }}{% if RenderInpc == false and RenderPrism == false %} { get; {% if property.HasSetter and RenderRecord == false %}set; {% endif %}}{% if property.HasDefaultValue and RenderRecord == false %} = {{ property.DefaultValue }};{% endif %}
 {% else %}
     {
         get { return {{ property.FieldName }}; }

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -190,6 +190,17 @@ namespace NJsonSchema.CodeGeneration
             {
                 return ConversionUtilities.ConvertToUpperCamelCase(input, firstCharacterMustBeAlpha);
             }
+
+            public static IEnumerable<object> Concat(Context context, IEnumerable<object> input, IEnumerable<object> concat)
+            {
+                return input.Concat(concat ?? Enumerable.Empty<object>()).ToList();
+            }
+
+            public static IEnumerable<object> Empty(Context context, object input)
+            {
+                return Enumerable.Empty<object>();
+            }
+
         }
 
         internal class TemplateTag : Tag

--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -200,7 +200,6 @@ namespace NJsonSchema.CodeGeneration
             {
                 return Enumerable.Empty<object>();
             }
-
         }
 
         internal class TemplateTag : Tag

--- a/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
@@ -37,7 +37,7 @@ namespace NJsonSchema.CodeGeneration.Models
         }
 
         /// <summary>Gets a value indicating whether the property has default value.</summary>
-        public bool HasDefaultValue => !string.IsNullOrEmpty(DefaultValue);
+        public bool HasDefaultValue => _settings.GenerateDefaultValues && !string.IsNullOrEmpty(DefaultValue);
 
         /// <summary>Gets the type of the property.</summary>
         public abstract string Type { get; }

--- a/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/PropertyModelBase.cs
@@ -30,20 +30,20 @@ namespace NJsonSchema.CodeGeneration.Models
         {
             _classTemplateModel = classTemplateModel;
             _property = property;
-            ValueGenerator = valueGenerator;
             _settings = settings;
 
+            ValueGenerator = valueGenerator;
             PropertyName = _settings.PropertyNameGenerator.Generate(_property);
         }
-
-        /// <summary>Gets a value indicating whether the property has default value.</summary>
-        public bool HasDefaultValue => _settings.GenerateDefaultValues && !string.IsNullOrEmpty(DefaultValue);
 
         /// <summary>Gets the type of the property.</summary>
         public abstract string Type { get; }
 
         /// <summary>Gets the default value generator.</summary>
         public ValueGeneratorBase ValueGenerator { get; }
+
+        /// <summary>Gets a value indicating whether the property has default value.</summary>
+        public bool HasDefaultValue => !string.IsNullOrEmpty(DefaultValue);
 
         /// <summary>Gets the default value as string.</summary>
         public string DefaultValue => ValueGenerator.GetDefaultValue(_property, 


### PR DESCRIPTION
Some fixies to records after real life usage:
* inheritance fix
* no more default values for records (bad practice from one side, and see below)
* properties in constructor now arranged in alphabetical order - this makes code more stable after refactoring (cleanup for ex) of original code and adding new properties.

Added:
* CS compilation assert for CS code (using Roslyn) 
* default generated namespace set to `System` (needed to pass compilation assert)