### PR TITLE
Updated to support Forcing ENUM to be bitwise

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -1596,6 +1596,35 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             AssertCompile(output);
         }
 
+        public class ClassWithExtensionData
+        {
+            public string Foo { get; set; }
+
+            [JsonExtensionData]
+            public IDictionary<string, object> ExtensionData { get; set; }
+        }
+
+        [Fact]
+        public async Task When_class_has_property_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithExtensionData>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
+            var json = schema.ToJson();
+
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco
+            });
+
+            //// Act
+            var output = generator.GenerateFile("PersonAddress");
+
+            //// Assert
+            Assert.Equal(1, schema.ActualProperties.Count);
+            Assert.True(schema.AllowAdditionalProperties);
+            Assert.True(schema.AdditionalPropertiesSchema.ActualSchema.IsAnyType);
+        }
+
         private static void AssertCompile(string code)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(code);

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpGeneratorTests.cs
@@ -1605,7 +1605,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
         }
 
         [Fact]
-        public async Task When_class_has_property_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set()
+        public async Task When_schema_has_AdditionProperties_schema_then_JsonExtensionDataAttribute_is_generated()
         {
             //// Arrange
             var schema = await JsonSchema4.FromTypeAsync<ClassWithExtensionData>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
@@ -1620,9 +1620,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             var output = generator.GenerateFile("PersonAddress");
 
             //// Assert
-            Assert.Equal(1, schema.ActualProperties.Count);
-            Assert.True(schema.AllowAdditionalProperties);
-            Assert.True(schema.AdditionalPropertiesSchema.ActualSchema.IsAnyType);
+            Assert.Contains("JsonExtensionData", output);
         }
 
         private static void AssertCompile(string code)

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -57,7 +57,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             }";
 
             var schema = await JsonSchema4.FromJsonAsync(json);
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { EnforceFlaggedEnums = true });
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { EnforceFlagEnums = true });
 
             //// Act
             var code = generator.GenerateFile("MyClass");

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -37,7 +37,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         }
 
         [Fact]
-        public async Task When_enum_has_no_type_then_enum_is_generated_withflags()
+        public async Task When_enum_has_no_type_then_enum_is_generated_with_flags()
         {
             //// Arrange
             var json =
@@ -55,10 +55,9 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
                     }
                 }
             }";
+
             var schema = await JsonSchema4.FromJsonAsync(json);
-
-
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings() { GenerateEnumAsBitFlags = true });
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings { EnforceFlaggedEnums = true });
 
             //// Act
             var code = generator.GenerateFile("MyClass");
@@ -69,7 +68,7 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             Assert.Contains("Residential = 2,", code);
             Assert.Contains("Government = 4,", code);
             Assert.Contains("Military = 8,", code);
-            Assert.Contains(" Foreigngovernment = 16,", code);
+            Assert.Contains("Foreigngovernment = 16,", code);
         }
 
         [Fact]

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -64,7 +64,12 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
             var code = generator.GenerateFile("MyClass");
 
             //// Assert
-            Assert.Contains("public enum MyClassCategory", code);
+            Assert.Contains("[System.Flags]", code);
+            Assert.Contains("Commercial = 1,", code);
+            Assert.Contains("Residential = 2,", code);
+            Assert.Contains("Government = 4,", code);
+            Assert.Contains("Military = 8,", code);
+            Assert.Contains(" Foreigngovernment = 16,", code);
         }
 
         [Fact]

--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/EnumTests.cs
@@ -37,6 +37,37 @@ namespace NJsonSchema.CodeGeneration.Tests.CSharp
         }
 
         [Fact]
+        public async Task When_enum_has_no_type_then_enum_is_generated_withflags()
+        {
+            //// Arrange
+            var json =
+            @"{
+                ""type"": ""object"", 
+                ""properties"": {
+                    ""category"" : {
+                        ""enum"" : [
+                            ""commercial"",
+                            ""residential"",
+                            ""government"",
+                            ""military"",
+                            ""foreigngovernment""
+                        ]
+                    }
+                }
+            }";
+            var schema = await JsonSchema4.FromJsonAsync(json);
+
+
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings() { GenerateEnumAsBitFlags = true });
+
+            //// Act
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public enum MyClassCategory", code);
+        }
+
+        [Fact]
         public async Task When_enum_name_contains_colon_then_it_is_removed_and_next_word_converted_to_upper_case()
         {
             //// Arrange

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -35,7 +35,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             TypeAccessModifier = "public";
             PropertySetterAccessModifier = string.Empty;
             GenerateJsonMethods = true;
-            EnforceFlaggedEnums = false;
+            EnforceFlagEnums = false;
 
             ValueGenerator = new CSharpValueGenerator(this);
             PropertyNameGenerator = new CSharpPropertyNameGenerator();
@@ -107,6 +107,6 @@ namespace NJsonSchema.CodeGeneration.CSharp
         public bool GenerateJsonMethods { get; set; }
 
         /// <summary>Gets or sets a value indicating whether enums should be always generated as bit flags (default: false).</summary>
-        public bool EnforceFlaggedEnums { get; set; }
+        public bool EnforceFlagEnums { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -35,6 +35,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             TypeAccessModifier = "public";
             PropertySetterAccessModifier = string.Empty;
             GenerateJsonMethods = true;
+            GenerateEnumAsBitFlags = false;
 
             ValueGenerator = new CSharpValueGenerator(this);
             PropertyNameGenerator = new CSharpPropertyNameGenerator();
@@ -104,5 +105,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether to render ToJson() and FromJson() methods (default: true).</summary>
         public bool GenerateJsonMethods { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether Enums should be Generated as bit flags (default: false.</summary>
+        public bool GenerateEnumAsBitFlags { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -35,7 +35,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             TypeAccessModifier = "public";
             PropertySetterAccessModifier = string.Empty;
             GenerateJsonMethods = true;
-            GenerateEnumAsBitFlags = false;
+            EnforceFlaggedEnums = false;
 
             ValueGenerator = new CSharpValueGenerator(this);
             PropertyNameGenerator = new CSharpPropertyNameGenerator();
@@ -106,7 +106,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
         /// <summary>Gets or sets a value indicating whether to render ToJson() and FromJson() methods (default: true).</summary>
         public bool GenerateJsonMethods { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether Enums should be Generated as bit flags (default: false.</summary>
-        public bool GenerateEnumAsBitFlags { get; set; }
+        /// <summary>Gets or sets a value indicating whether enums should be always generated as bit flags (default: false).</summary>
+        public bool EnforceFlaggedEnums { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -47,7 +47,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string TypeAccessModifier => _settings.TypeAccessModifier;
 
         /// <summary>Gets or sets if we output as Bit Flags.</summary>
-        public bool IsEnumAsBitFlags => _settings.GenerateEnumAsBitFlags;
+        public bool IsEnumAsBitFlags => _settings.EnforceFlaggedEnums || _schema.IsFlaggedEnumerable;
 
         /// <summary>Gets the enum values.</summary>
         public IEnumerable<EnumerationItemModel> Enums

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -47,7 +47,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         public string TypeAccessModifier => _settings.TypeAccessModifier;
 
         /// <summary>Gets or sets if we output as Bit Flags.</summary>
-        public bool IsEnumAsBitFlags => _settings.EnforceFlaggedEnums || _schema.IsFlaggedEnumerable;
+        public bool IsEnumAsBitFlags => _settings.EnforceFlagEnums || _schema.IsFlagEnumerable;
 
         /// <summary>Gets the enum values.</summary>
         public IEnumerable<EnumerationItemModel> Enums

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -69,7 +69,7 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                             Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
                             Value = value.ToString(),
                             InternalValue = _schema.Type.HasFlag(JsonObjectType.Integer) ? value.ToString() : i.ToString(),
-                            InternalFlagValue = i == 0 ? "0" : (1 << i).ToString()
+                            InternalFlagValue = (1 << i).ToString()
                         });
                     }
                 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/EnumTemplateModel.cs
@@ -46,6 +46,9 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets or sets the access modifier of generated classes and interfaces.</summary>
         public string TypeAccessModifier => _settings.TypeAccessModifier;
 
+        /// <summary>Gets or sets if we output as Bit Flags.</summary>
+        public bool IsEnumAsBitFlags => _settings.GenerateEnumAsBitFlags;
+
         /// <summary>Gets the enum values.</summary>
         public IEnumerable<EnumerationItemModel> Enums
         {
@@ -65,7 +68,8 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
                         {
                             Name = _settings.EnumNameGenerator.Generate(i, name, value, _schema),
                             Value = value.ToString(),
-                            InternalValue = _schema.Type.HasFlag(JsonObjectType.Integer) ? value.ToString() : i.ToString()
+                            InternalValue = _schema.Type.HasFlag(JsonObjectType.Integer) ? value.ToString() : i.ToString(),
+                            InternalFlagValue = i == 0 ? "0" : (1 << i).ToString()
                         });
                     }
                 }

--- a/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.53</Version>
+    <Version>9.10.54</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
+++ b/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.52</Version>
+    <Version>9.10.53</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -80,6 +80,7 @@
         get { return _additionalProperties; }
         {{PropertySetterAccessModifier}}set { _additionalProperties = value; }
     }
+
 {% endif -%}
 {% if GenerateJsonMethods -%}
     {% template Class.ToJson %}

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Enum.liquid
@@ -2,13 +2,22 @@
 /// <summary>{{ Description | csharpdocs }}</summary>
 {% endif -%}
 [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "{{ ToolchainVersion }}")]
+{% if IsEnumAsBitFlags -%}
+[System.Flags]
+{% endif -%}
 {{ TypeAccessModifier }} enum {{ Name }}
 {
 {% for enum in Enums -%}
 {%   if IsStringEnum -%}
     [System.Runtime.Serialization.EnumMember(Value = "{{ enum.Value }}")]
 {%   endif -%}
+
+{% if IsEnumAsBitFlags -%}
+    {{ enum.Name }} = {{ enum.InternalFlagValue }},
+{% else -%}
     {{ enum.Name }} = {{ enum.InternalValue }},
+{% endif -%}
+
 
 {% endfor -%}
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.53</Version>
+    <Version>9.10.54</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.52</Version>
+    <Version>9.10.53</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema.CodeGeneration/Models/EnumerationItemModel.cs
+++ b/src/NJsonSchema.CodeGeneration/Models/EnumerationItemModel.cs
@@ -19,5 +19,8 @@ namespace NJsonSchema.CodeGeneration.Models
 
         /// <summary>Gets or sets the internal value (e.g. the underlying/system value).</summary>
         public string InternalValue { get; set; }
+
+        /// <summary>Gets or sets the internal flag value (e.g. the underlying/system value).</summary>
+        public string InternalFlagValue { get; set; }
     }
 }

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.53</Version>
+    <Version>9.10.54</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
+++ b/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.52</Version>
+    <Version>9.10.53</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema.Tests/Generation/ArrayGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ArrayGenerationTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NJsonSchema.Generation;
+using Xunit;
+
+namespace NJsonSchema.Tests.Generation
+{
+    public class ArrayGenerationTests
+    {
+        public class ClassWithJArray
+        {
+            public string Foo { get; set; }
+
+            public JArray Array { get; set; }
+        }
+
+        [Fact]
+        public async Task When_property_is_JArray_then_schema_with_any_array_is_generated()
+        {
+            //// Act
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithJArray>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
+            var json = schema.ToJson();
+
+            //// Assert
+            Assert.Equal(2, schema.ActualProperties.Count);
+            var arrayProperty = schema.ActualProperties["Array"].ActualTypeSchema;
+            Assert.Equal(JsonObjectType.Array, arrayProperty.Type);
+            Assert.True(arrayProperty.Item.ActualTypeSchema.IsAnyType);
+        }
+    }
+}

--- a/src/NJsonSchema.Tests/Generation/EnumTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using NJsonSchema.Generation;
 using Xunit;
 
@@ -68,7 +71,40 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.True(schema.Properties["Dictionary"].AdditionalPropertiesSchema.HasReference); 
+            Assert.True(schema.Properties["Dictionary"].AdditionalPropertiesSchema.HasReference);
+        }
+
+        public enum MyEnum
+        {
+            Value1,
+            Value2
+        }
+
+        [Fact]
+        public async Task When_SerializerSettings_has_CamelCase_StringEnumConverter_then_enum_values_are_correct()
+        {
+            // Arrange
+            var settings = new JsonSchemaGeneratorSettings
+            {
+                SerializerSettings = new JsonSerializerSettings
+                {
+                    Converters =
+                    {
+                        new StringEnumConverter { CamelCaseText = true }
+                    }
+                }
+            };
+
+            // Act
+            var schema = await JsonSchema4.FromTypeAsync<MyEnum>(settings);
+            var json = schema.ToJson();
+
+            // Assert
+            Assert.Equal("value1", schema.Enumeration.First());
+            Assert.Equal("value2", schema.Enumeration.Last());
+
+            Assert.Equal("Value1", schema.EnumerationNames.First());
+            Assert.Equal("Value2", schema.EnumerationNames.Last());
         }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/EnumTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumTests.cs
@@ -106,5 +106,54 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal("Value1", schema.EnumerationNames.First());
             Assert.Equal("Value2", schema.EnumerationNames.Last());
         }
+
+        [Flags]
+        public enum EnumWithFlags
+        {
+            Foo = 1,
+            Bar = 2,
+            Baz = 4,
+        }
+
+        [Fact]
+        public async Task When_enum_has_FlagsAttribute_then_custom_property_is_set()
+        {
+            // Arrange
+
+            //// Act
+            var schema = await JsonSchema4.FromTypeAsync<EnumWithFlags>(new JsonSchemaGeneratorSettings
+            {
+                DefaultEnumHandling = EnumHandling.String
+            });
+            var json = schema.ToJson();
+
+            // Assert
+            Assert.True(schema.IsFlaggedEnumerable);
+            Assert.Contains("x-enumFlags", json);
+        }
+
+        public enum EnumWithoutFlags
+        {
+            Foo = 1,
+            Bar = 2,
+            Baz = 3,
+        }
+
+        [Fact]
+        public async Task When_enum_does_not_have_FlagsAttribute_then_custom_property_is_not_set()
+        {
+            // Arrange
+
+            //// Act
+            var schema = await JsonSchema4.FromTypeAsync<EnumWithoutFlags>(new JsonSchemaGeneratorSettings
+            {
+                DefaultEnumHandling = EnumHandling.String
+            });
+            var json = schema.ToJson();
+
+            // Assert
+            Assert.False(schema.IsFlaggedEnumerable);
+            Assert.DoesNotContain("x-enumFlags", json);
+        }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/EnumTests.cs
+++ b/src/NJsonSchema.Tests/Generation/EnumTests.cs
@@ -128,7 +128,7 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.True(schema.IsFlaggedEnumerable);
+            Assert.True(schema.IsFlagEnumerable);
             Assert.Contains("x-enumFlags", json);
         }
 
@@ -152,7 +152,7 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.False(schema.IsFlaggedEnumerable);
+            Assert.False(schema.IsFlagEnumerable);
             Assert.DoesNotContain("x-enumFlags", json);
         }
 
@@ -177,7 +177,7 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.True(schema.IsFlaggedEnumerable);
+            Assert.True(schema.IsFlagEnumerable);
             Assert.Contains("x-enumFlags", json);
         }
 
@@ -201,7 +201,7 @@ namespace NJsonSchema.Tests.Generation
             var json = schema.ToJson();
 
             // Assert
-            Assert.False(schema.IsFlaggedEnumerable);
+            Assert.False(schema.IsFlagEnumerable);
             Assert.DoesNotContain("x-enumFlags", json);
         }
     }

--- a/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/ExtensionDataGenerationTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NJsonSchema.Generation;
+using Xunit;
+
+namespace NJsonSchema.Tests.Generation
+{
+    public class ExtensionDataGenerationTests
+    {
+        public class ClassWithExtensionData
+        {
+            public string Foo { get; set; }
+
+            [JsonExtensionData]
+            public IDictionary<string, object> ExtensionData { get; set; }
+        }
+
+        [Fact]
+        public async Task When_class_has_property_with_JsonExtensionDataAttribute_on_property_then_AdditionalProperties_schema_is_set()
+        {
+            //// Act
+            var schema = await JsonSchema4.FromTypeAsync<ClassWithExtensionData>(new JsonSchemaGeneratorSettings { SchemaType = SchemaType.OpenApi3 });
+            var json = schema.ToJson();
+
+            //// Assert
+            Assert.Equal(1, schema.ActualProperties.Count);
+            Assert.True(schema.AllowAdditionalProperties);
+            Assert.True(schema.AdditionalPropertiesSchema.ActualSchema.IsAnyType);
+        }
+    }
+}

--- a/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
+++ b/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.52</Version>
+    <Version>9.10.53</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
+++ b/src/NJsonSchema.Yaml/NJsonSchema.Yaml.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.53</Version>
+    <Version>9.10.54</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema/EnumHandling.cs
+++ b/src/NJsonSchema/EnumHandling.cs
@@ -16,5 +16,8 @@ namespace NJsonSchema
 
         /// <summary>Generates a string field with JSON Schema enumeration.</summary>
         String,
+
+        /// <summary>Generates a camel-cased string field with JSON Schema enumeration.</summary>
+        CamelCaseString,
     }
 }

--- a/src/NJsonSchema/Generation/DefaultReflectionService.cs
+++ b/src/NJsonSchema/Generation/DefaultReflectionService.cs
@@ -105,6 +105,9 @@ namespace NJsonSchema.Generation
             if (type == typeof(byte[]))
                 return JsonTypeDescription.Create(type, JsonObjectType.String, isNullable, JsonFormatStrings.Byte);
 
+            if (type == typeof(JArray))
+                return JsonTypeDescription.Create(type, JsonObjectType.Array, isNullable, null);
+
             if (type == typeof(JObject) || 
                 type == typeof(JToken) ||
                 type.FullName == "System.Dynamic.ExpandoObject" ||

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -742,6 +742,7 @@ namespace NJsonSchema.Generation
             schema.Type = typeDescription.Type;
             schema.Enumeration.Clear();
             schema.EnumerationNames.Clear();
+            schema.IsFlaggedEnumerable = type.GetTypeInfo().GetCustomAttribute<FlagsAttribute>() != null;
 
             var underlyingType = Enum.GetUnderlyingType(type);
 

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -742,7 +742,7 @@ namespace NJsonSchema.Generation
             schema.Type = typeDescription.Type;
             schema.Enumeration.Clear();
             schema.EnumerationNames.Clear();
-            schema.IsFlaggedEnumerable = type.GetTypeInfo().GetCustomAttribute<FlagsAttribute>() != null;
+            schema.IsFlagEnumerable = type.GetTypeInfo().GetCustomAttribute<FlagsAttribute>() != null;
 
             var underlyingType = Enum.GetUnderlyingType(type);
 

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -411,6 +411,10 @@ namespace NJsonSchema
         [JsonProperty("x-example", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public object Example { get; set; }
 
+        /// <summary>Gets or sets a value indicating this is an bit flag enum (custom extension, sets 'x-enumFlags', default: false).</summary>
+        [JsonProperty("x-enumFlags", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public bool IsFlaggedEnumerable { get; set; }
+
         /// <summary>Gets the collection of required properties. </summary>
         [JsonIgnore]
         public ICollection<object> Enumeration { get; internal set; }

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -413,7 +413,7 @@ namespace NJsonSchema
 
         /// <summary>Gets or sets a value indicating this is an bit flag enum (custom extension, sets 'x-enumFlags', default: false).</summary>
         [JsonProperty("x-enumFlags", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public bool IsFlaggedEnumerable { get; set; }
+        public bool IsFlagEnumerable { get; set; }
 
         /// <summary>Gets the collection of required properties. </summary>
         [JsonIgnore]

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net40;net45</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.52</Version>
+    <Version>9.10.53</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/NJsonSchema/NJsonSchema.csproj
+++ b/src/NJsonSchema/NJsonSchema.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net40;net45</TargetFrameworks>
     <Description>JSON Schema reader, generator and validator for .NET</Description>
-    <Version>9.10.53</Version>
+    <Version>9.10.54</Version>
     <PackageTags>json schema validation generator .net</PackageTags>
     <Copyright>Copyright © Rico Suter, 2017</Copyright>
     <PackageLicenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</PackageLicenseUrl>


### PR DESCRIPTION
The OpenApi/Swagger specs don't lend themselves easily to BITWISE ENUMS.

Updated the CSharpGeneratorSettings to add a flag (default:false) to allow creating ENUMs that are BITWISE flags