### PR TITLE
Improved XML documentation reader

### DIFF
--- a/src/NJsonSchema.Tests/Generation/XmlDocTests.cs
+++ b/src/NJsonSchema.Tests/Generation/XmlDocTests.cs
@@ -69,7 +69,7 @@ namespace NJsonSchema.Tests.Generation
 
         public class WithSeeTagInXmlDoc
         {
-            /// <summary><see langword="null"/> for the default <see cref="Record"/>.</summary>
+            /// <summary><see langword="null"/> for the default <see cref="Record"/>. See <see cref="Record">this</see> and <see href="https://github.com/rsuter/njsonschema">this</see> at <see href="https://github.com/rsuter/njsonschema"/>.</summary>
             public string Foo { get; set; }
         }
 
@@ -83,7 +83,26 @@ namespace NJsonSchema.Tests.Generation
             var summary = await typeof(WithSeeTagInXmlDoc).GetProperty("Foo").GetXmlSummaryAsync();
 
             //// Assert
-            Assert.Equal("null for the default Record.", summary);
+            Assert.Equal("null for the default Record. See this and this at https://github.com/rsuter/njsonschema.", summary);
+        }
+
+        public class WithGenericTagsInXmlDoc
+        {
+            /// <summary>This <c>are</c> <strong>some</strong> tags.</summary>
+            public string Foo { get; set; }
+        }
+
+        [Fact]
+        public async Task When_summary_has_generic_tags_then_it_is_converted()
+        {
+            //// Arrange
+
+
+            //// Act
+            var summary = await typeof(WithGenericTagsInXmlDoc).GetProperty("Foo").GetXmlSummaryAsync();
+
+            //// Assert
+            Assert.Equal("This are some tags.", summary);
         }
 
         [Fact]

--- a/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
@@ -209,7 +209,7 @@ namespace NJsonSchema.Infrastructure
                             return null;
                         }
 
-                        Cache[assemblyName.FullName] = await Task.Factory.StartNew(() => XDocument.Load(pathToXmlFile)).ConfigureAwait(false);
+                        Cache[assemblyName.FullName] = await Task.Factory.StartNew(() => XDocument.Load(pathToXmlFile, LoadOptions.PreserveWhitespace)).ConfigureAwait(false);
                     }
                     else if (Cache[assemblyName.FullName] == null)
                         return null;
@@ -344,9 +344,20 @@ namespace NJsonSchema.Infrastructure
                                 value.Append(attribute.Value);
                             else
                             {
-                                attribute = e.Attribute("cref");
-                                if (attribute != null)
-                                    value.Append(attribute.Value.Trim('!', ':').Trim().Split('.').Last());
+                                if (!string.IsNullOrEmpty(e.Value))
+                                    value.Append(e.Value);
+                                else
+                                {
+                                    attribute = e.Attribute("cref");
+                                    if (attribute != null)
+                                        value.Append(attribute.Value.Trim('!', ':').Trim().Split('.').Last());
+                                    else
+                                    {
+                                        attribute = e.Attribute("href");
+                                        if (attribute != null)
+                                            value.Append(attribute.Value);
+                                    }
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
Added a few more cases that were not supported for the `see` tag:

1. `<see cref="Record">this</see>`
2. `<see href="https://github.com/rsuter/njsonschema">this</see>`
3. `<see href="https://github.com/rsuter/njsonschema"/>`

Changed the XML document loading to preserve white space to support `This <c>are</c> <strong>some</strong> tags.`. Although this might hinder some more _artistic_ markup.