### PR TITLE
Support for YAML references

### DIFF
--- a/build/04_RunTests.bat
+++ b/build/04_RunTests.bat
@@ -2,3 +2,4 @@ dotnet test "%~dp0/../src\NJsonSchema.Tests\NJsonSchema.Tests.csproj" -c Release
 dotnet test "%~dp0/../src\NJsonSchema.CodeGeneration.Tests\NJsonSchema.CodeGeneration.Tests.csproj" -c Release
 dotnet test "%~dp0/../src\NJsonSchema.CodeGeneration.CSharp.Tests\NJsonSchema.CodeGeneration.CSharp.Tests.csproj" -c Release
 dotnet test "%~dp0/../src\NJsonSchema.CodeGeneration.TypeScript.Tests\NJsonSchema.CodeGeneration.TypeScript.Tests.csproj" -c Release
+dotnet test "%~dp0/../src\NJsonSchema.Yaml.Tests\NJsonSchema.Yaml.Tests.csproj" -c Release

--- a/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
+++ b/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net46;net45</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="System.ComponentModel.Annotations" Version="4.4.0" />
+    <Reference Condition="'$(TargetFramework)' == 'net45'" Include="System.ComponentModel.DataAnnotations">
+    </Reference>
+    <Reference Condition="'$(TargetFramework)' == 'net46'" Include="System.ComponentModel.DataAnnotations">
+    </Reference>
+    <PackageReference Include="NodaTime" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NJsonSchema\NJsonSchema.csproj" />
+    <ProjectReference Include="..\NJsonSchema.Yaml\NJsonSchema.Yaml.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="References\YamlReferencesTest\collection.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="References\YamlReferencesTest\collection.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="References\YamlReferencesTest\json_schema_with_yaml_reference.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>  
+    <Content Include="References\YamlReferencesTest\json_schema_with_json_reference.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="References\YamlReferencesTest\yaml_schema_with_json_reference.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="References\YamlReferencesTest\yaml_schema_with_yaml_reference.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
+++ b/src/NJsonSchema.Yaml.Tests/NJsonSchema.Yaml.Tests.csproj
@@ -3,6 +3,9 @@
     <TargetFrameworks>netcoreapp2.0;net46;net45</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <PropertyGroup>
+      <DocumentationFile>bin\Debug\$(TargetFramework)\NJsonSchema.Yaml.Tests.xml</DocumentationFile>
+  </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/collection.json
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/collection.json
@@ -1,0 +1,8 @@
+{
+	"myInt": {
+		"type": "integer"
+	},
+	"myBool": {
+		"type": "boolean"
+	}
+}

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/collection.yaml
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/collection.yaml
@@ -1,0 +1,5 @@
+---
+myInt:
+  type: integer
+myBool:
+  type: boolean

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/json_schema_with_json_reference.json
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/json_schema_with_json_reference.json
@@ -1,0 +1,16 @@
+{
+	"type": "object",
+  "properties": {
+    "bar": {
+      "$ref": "./collection.json#/myBool"
+    },
+    "foo": {
+      "$ref": "#/definitions/collection/myInt"
+    }
+  },
+	"definitions": {
+		"collection": {
+			"$ref": "./collection.json"
+		}
+	}
+}

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/json_schema_with_yaml_reference.json
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/json_schema_with_yaml_reference.json
@@ -1,0 +1,16 @@
+{
+	"type": "object",
+  "properties": {
+    "bar": {
+      "$ref": "./collection.yaml#/myBool"
+    },
+    "foo": {
+      "$ref": "#/definitions/collection/myInt"
+    }
+  },
+	"definitions": {
+		"collection": {
+			"$ref": "./collection.yaml"
+		}
+	}
+}

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/yaml_schema_with_json_reference.yaml
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/yaml_schema_with_json_reference.yaml
@@ -1,0 +1,10 @@
+---
+type: object
+properties:
+  bar:
+    "$ref": "./collection.json#/myBool"
+  foo:
+    "$ref": "#/definitions/collection/myInt"
+definitions:
+  collection:
+    "$ref": "./collection.json"

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/yaml_schema_with_yaml_reference.yaml
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTest/yaml_schema_with_yaml_reference.yaml
@@ -1,0 +1,10 @@
+---
+type: object
+properties:
+  bar:
+    "$ref": "./collection.yaml#/myBool"
+  foo:
+    "$ref": "#/definitions/collection/myInt"
+definitions:
+  collection:
+    "$ref": "./collection.yaml"

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTests.cs
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.Yaml.Tests.References
+{
+    public class LocalReferencesTests
+    {
+        [Theory]
+        [InlineData("/References/YamlReferencesTest/json_schema_with_json_reference.json")]
+        [InlineData("/References/YamlReferencesTest/yaml_schema_with_json_reference.yaml")]
+        [InlineData("/References/YamlReferencesTest/yaml_schema_with_yaml_reference.yaml")]
+        [InlineData("/References/YamlReferencesTest/json_schema_with_yaml_reference.json")]
+        public async Task When_yaml_schema_has_references_it_works(string relativePath)
+        {
+            //// Arrange
+            var path = GetTestDirectory() + relativePath;
+
+            //// Act
+            var schema = await JsonSchemaYaml.FromFileAsync(path);
+            var json = schema.ToJson();
+
+            //// Assert
+            Assert.Equal(JsonObjectType.Integer, schema.Properties["foo"].ActualTypeSchema.Type);
+            Assert.Equal(1, schema.Definitions.Count);
+            Assert.Equal("./collection.json", schema.Definitions["collection"].DocumentPath);
+        }
+
+        private string GetTestDirectory()
+        {
+            var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            var uri = new UriBuilder(codeBase);
+            return Path.GetDirectoryName(Uri.UnescapeDataString(uri.Path));
+        }
+    }
+}

--- a/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTests.cs
+++ b/src/NJsonSchema.Yaml.Tests/References/YamlReferencesTests.cs
@@ -9,11 +9,11 @@ namespace NJsonSchema.Yaml.Tests.References
     public class LocalReferencesTests
     {
         [Theory]
-        [InlineData("/References/YamlReferencesTest/json_schema_with_json_reference.json")]
-        [InlineData("/References/YamlReferencesTest/yaml_schema_with_json_reference.yaml")]
-        [InlineData("/References/YamlReferencesTest/yaml_schema_with_yaml_reference.yaml")]
-        [InlineData("/References/YamlReferencesTest/json_schema_with_yaml_reference.json")]
-        public async Task When_yaml_schema_has_references_it_works(string relativePath)
+        [InlineData("/References/YamlReferencesTest/json_schema_with_json_reference.json", "./collection.json")]
+        [InlineData("/References/YamlReferencesTest/yaml_schema_with_json_reference.yaml", "./collection.json")]
+        [InlineData("/References/YamlReferencesTest/yaml_schema_with_yaml_reference.yaml", "./collection.yaml")]
+        [InlineData("/References/YamlReferencesTest/json_schema_with_yaml_reference.json", "./collection.yaml")]
+        public async Task When_yaml_schema_has_references_it_works(string relativePath, string documentPath)
         {
             //// Arrange
             var path = GetTestDirectory() + relativePath;
@@ -25,7 +25,7 @@ namespace NJsonSchema.Yaml.Tests.References
             //// Assert
             Assert.Equal(JsonObjectType.Integer, schema.Properties["foo"].ActualTypeSchema.Type);
             Assert.Equal(1, schema.Definitions.Count);
-            Assert.Equal("./collection.json", schema.Definitions["collection"].DocumentPath);
+            Assert.Equal(documentPath, schema.Definitions["collection"].DocumentPath);
         }
 
         private string GetTestDirectory()

--- a/src/NJsonSchema.Yaml/JsonSchemaYaml.cs
+++ b/src/NJsonSchema.Yaml/JsonSchemaYaml.cs
@@ -25,15 +25,7 @@ namespace NJsonSchema.Yaml
         /// <returns>The <see cref="JsonSchema4"/>.</returns>
         public static async Task<JsonSchema4> FromYamlAsync(string data, string documentPath = null)
         {
-            var deserializer = new DeserializerBuilder().Build();
-            var yamlObject = deserializer.Deserialize(new StringReader(data));
-
-            var serializer = new SerializerBuilder()
-                .JsonCompatible()
-                .Build();
-
-            var json = serializer.Serialize(yamlObject);
-            return await JsonSchema4.FromJsonAsync(json, documentPath).ConfigureAwait(false);
+            return await JsonSchema4.FromJsonAsync(data, documentPath, ConvertYamlToJson).ConfigureAwait(false);
         }
 
         /// <summary>Converts the JSON Schema to YAML.</summary>
@@ -64,6 +56,19 @@ namespace NJsonSchema.Yaml
         {
             var data = await DynamicApis.HttpGetAsync(url).ConfigureAwait(false);
             return await FromYamlAsync(data, url).ConfigureAwait(false);
+        }
+        
+        private static string ConvertYamlToJson(string data)
+        {
+            var deserializer = new DeserializerBuilder().Build();
+            var yamlObject = deserializer.Deserialize(new StringReader(data));
+
+            var serializer = new SerializerBuilder()
+                .JsonCompatible()
+                .Build();
+
+            var json = serializer.Serialize(yamlObject);
+            return json;
         }
     }
 }

--- a/src/NJsonSchema.sln
+++ b/src/NJsonSchema.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+VisualStudioVersion = 15.0.26403.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NJsonSchema", "NJsonSchema\NJsonSchema.csproj", "{7B7A2E32-E808-4A19-98B1-37E766580F8C}"
 EndProject
@@ -25,9 +25,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NJsonSchema.CodeGeneration.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NJsonSchema.Yaml", "NJsonSchema.Yaml\NJsonSchema.Yaml.csproj", "{9EAB6FAB-10AC-4AB2-BA5B-103CE6A17E88}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NJsonSchema.Demo.Performance", "NJsonSchema.Demo.Performance\NJsonSchema.Demo.Performance.csproj", "{75B834E0-1F0D-4BC2-911D-5CF079BCE73B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NJsonSchema.Demo.Performance", "NJsonSchema.Demo.Performance\NJsonSchema.Demo.Performance.csproj", "{75B834E0-1F0D-4BC2-911D-5CF079BCE73B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NJsonSchema.Benchmark", "NJsonSchema.Benchmark\NJsonSchema.Benchmark.csproj", "{E59CE32B-181F-4AAE-BF62-772AEEFC3177}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NJsonSchema.Benchmark", "NJsonSchema.Benchmark\NJsonSchema.Benchmark.csproj", "{E59CE32B-181F-4AAE-BF62-772AEEFC3177}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NJsonSchema.Yaml.Tests", "NJsonSchema.Yaml.Tests\NJsonSchema.Yaml.Tests.csproj", "{990EF464-C967-4E08-8C3D-0568A47B6D2A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -209,6 +211,22 @@ Global
 		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|x64.Build.0 = Release|Any CPU
 		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|x86.ActiveCfg = Release|Any CPU
 		{E59CE32B-181F-4AAE-BF62-772AEEFC3177}.Release|x86.Build.0 = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|ARM.Build.0 = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|x64.Build.0 = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Debug|x86.Build.0 = Debug|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|ARM.ActiveCfg = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|ARM.Build.0 = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|x64.ActiveCfg = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|x64.Build.0 = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|x86.ActiveCfg = Release|Any CPU
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -221,6 +239,7 @@ Global
 		{E767A007-6007-4898-B80A-FE4ACBF2C588} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
 		{75B834E0-1F0D-4BC2-911D-5CF079BCE73B} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
 		{E59CE32B-181F-4AAE-BF62-772AEEFC3177} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
+		{990EF464-C967-4E08-8C3D-0568A47B6D2A} = {785552E3-F3BB-4AEB-B5CF-819AE38AEA8F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9D5EDC80-5611-493B-804B-8B364816952B}

--- a/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
+++ b/src/NJsonSchema/Infrastructure/JsonSchemaSerialization.cs
@@ -63,13 +63,16 @@ namespace NJsonSchema.Infrastructure
         /// <param name="documentPath">The document path.</param>
         /// <param name="referenceResolverFactory">The reference resolver factory.</param>
         /// <param name="contractResolver">The contract resolver.</param>
+        /// <param name="transformFunc">Function to transform source data.</param>
         /// <returns>The deserialized schema.</returns>
         public static async Task<T> FromJsonAsync<T>(string json, SchemaType schemaType, string documentPath,
-            Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver)
+            Func<T, JsonReferenceResolver> referenceResolverFactory, IContractResolver contractResolver,
+            Func<string, string> transformFunc)
         {
             IsWriting = true;
             CurrentSchemaType = schemaType;
 
+            json = transformFunc?.Invoke(json) ?? json;
             json = JsonSchemaReferenceUtilities.ConvertJsonReferences(json);
             var settings = new JsonSerializerSettings
             {
@@ -91,7 +94,8 @@ namespace NJsonSchema.Infrastructure
                     referenceResolver.AddDocumentReference(documentPath, referenceSchema);
             }
 
-            await JsonSchemaReferenceUtilities.UpdateSchemaReferencesAsync(schema, referenceResolver, contractResolver).ConfigureAwait(false);
+            await JsonSchemaReferenceUtilities.UpdateSchemaReferencesAsync(schema, referenceResolver, contractResolver)
+                .ConfigureAwait(false);
             return schema;
         }
     }

--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -21,13 +21,22 @@ namespace NJsonSchema
     public class JsonReferenceResolver
     {
         private readonly JsonSchemaResolver _schemaResolver;
+        private readonly JsonReferenceResolverSettings _settings;
         private readonly Dictionary<string, IJsonReference> _resolvedObjects = new Dictionary<string, IJsonReference>();
+
+        /// <inheritdoc />
+        public JsonReferenceResolver(JsonSchemaResolver schemaResolver)
+            :this(schemaResolver, new JsonReferenceResolverSettings())
+        {
+        }
 
         /// <summary>Initializes a new instance of the <see cref="JsonReferenceResolver"/> class.</summary>
         /// <param name="schemaResolver">The schema resolver.</param>
-        public JsonReferenceResolver(JsonSchemaResolver schemaResolver)
+        /// <param name="settings">The settings.</param>
+        public JsonReferenceResolver(JsonSchemaResolver schemaResolver, JsonReferenceResolverSettings settings)
         {
             _schemaResolver = schemaResolver;
+            _settings = settings;
         }
 
         /// <summary>Adds a document reference.</summary>
@@ -80,7 +89,7 @@ namespace NJsonSchema
         /// <exception cref="NotSupportedException">The System.IO.File API is not available on this platform.</exception>
         public virtual async Task<IJsonReference> ResolveFileReferenceAsync(string filePath)
         {
-            return await JsonSchema4.FromFileAsync(filePath, schema => this).ConfigureAwait(false);
+            return await JsonSchema4.FromFileAsync(filePath, schema => this, _settings.TransformationFunction).ConfigureAwait(false);
         }
 
         /// <summary>Resolves an URL reference.</summary>
@@ -88,7 +97,7 @@ namespace NJsonSchema
         /// <exception cref="NotSupportedException">The HttpClient.GetAsync API is not available on this platform.</exception>
         public virtual async Task<IJsonReference> ResolveUrlReferenceAsync(string url)
         {
-            return await JsonSchema4.FromUrlAsync(url, schema => this).ConfigureAwait(false);
+            return await JsonSchema4.FromUrlAsync(url, schema => this, _settings.TransformationFunction).ConfigureAwait(false);
         }
 
         private async Task<IJsonReference> ResolveReferenceAsync(object rootObject, string jsonPath, bool append)
@@ -96,16 +105,18 @@ namespace NJsonSchema
             if (jsonPath == "#")
             {
                 if (rootObject is IJsonReference)
-                    return (IJsonReference)rootObject;
+                    return (IJsonReference) rootObject;
 
-                throw new InvalidOperationException("Could not resolve the JSON path '#' because the root object is not a JsonSchema4.");
+                throw new InvalidOperationException(
+                    "Could not resolve the JSON path '#' because the root object is not a JsonSchema4.");
             }
             else if (jsonPath.StartsWith("#/"))
             {
                 return ResolveDocumentReference(rootObject, jsonPath);
             }
             else if (jsonPath.StartsWith("http://") || jsonPath.StartsWith("https://"))
-                return await ResolveUrlReferenceWithAlreadyResolvedCheckAsync(jsonPath, jsonPath, append).ConfigureAwait(false);
+                return await ResolveUrlReferenceWithAlreadyResolvedCheckAsync(jsonPath, jsonPath, append)
+                    .ConfigureAwait(false);
             else
             {
                 var documentPathProvider = rootObject as IDocumentPathProvider;
@@ -116,20 +127,25 @@ namespace NJsonSchema
                     if (documentPath.StartsWith("http://") || documentPath.StartsWith("https://"))
                     {
                         var url = new Uri(new Uri(documentPath), jsonPath).ToString();
-                        return await ResolveUrlReferenceWithAlreadyResolvedCheckAsync(url, jsonPath, append).ConfigureAwait(false);
+                        return await ResolveUrlReferenceWithAlreadyResolvedCheckAsync(url, jsonPath, append)
+                            .ConfigureAwait(false);
                     }
                     else
                     {
-                        var filePath = DynamicApis.PathCombine(DynamicApis.PathGetDirectoryName(documentPath), jsonPath);
-                        return await ResolveFileReferenceWithAlreadyResolvedCheckAsync(filePath, jsonPath, append).ConfigureAwait(false);
+                        var filePath =
+                            DynamicApis.PathCombine(DynamicApis.PathGetDirectoryName(documentPath), jsonPath);
+                        return await ResolveFileReferenceWithAlreadyResolvedCheckAsync(filePath, jsonPath, append)
+                            .ConfigureAwait(false);
                     }
                 }
                 else
-                    throw new NotSupportedException("Could not resolve the JSON path '" + jsonPath + "' because no document path is available.");
+                    throw new NotSupportedException("Could not resolve the JSON path '" + jsonPath +
+                                                    "' because no document path is available.");
             }
         }
 
-        private async Task<IJsonReference> ResolveFileReferenceWithAlreadyResolvedCheckAsync(string fullJsonPath, string jsonPath, bool append)
+        private async Task<IJsonReference> ResolveFileReferenceWithAlreadyResolvedCheckAsync(string fullJsonPath,
+            string jsonPath, bool append)
         {
             try
             {
@@ -140,7 +156,8 @@ namespace NJsonSchema
                     var schema = await ResolveFileReferenceAsync(filePath).ConfigureAwait(false);
                     schema.DocumentPath = jsonPath;
                     if (schema is JsonSchema4 && append)
-                        _schemaResolver.AppendSchema((JsonSchema4)schema, filePath.Split('/', '\\').Last().Split('.').First());
+                        _schemaResolver.AppendSchema((JsonSchema4) schema,
+                            filePath.Split('/', '\\').Last().Split('.').First());
 
                     _resolvedObjects[filePath] = schema;
                 }
@@ -150,11 +167,14 @@ namespace NJsonSchema
             }
             catch (Exception exception)
             {
-                throw new InvalidOperationException("Could not resolve the JSON path '" + jsonPath + "' with the full JSON path '" + fullJsonPath + "'.", exception);
+                throw new InvalidOperationException(
+                    "Could not resolve the JSON path '" + jsonPath + "' with the full JSON path '" + fullJsonPath +
+                    "'.", exception);
             }
         }
 
-        private async Task<IJsonReference> ResolveUrlReferenceWithAlreadyResolvedCheckAsync(string fullJsonPath, string jsonPath, bool append)
+        private async Task<IJsonReference> ResolveUrlReferenceWithAlreadyResolvedCheckAsync(string fullJsonPath,
+            string jsonPath, bool append)
         {
             try
             {
@@ -164,28 +184,34 @@ namespace NJsonSchema
                     var schema = await ResolveUrlReferenceAsync(arr[0]).ConfigureAwait(false);
                     schema.DocumentPath = jsonPath;
                     if (schema is JsonSchema4 && append)
-                        _schemaResolver.AppendSchema((JsonSchema4)schema, null);
+                        _schemaResolver.AppendSchema((JsonSchema4) schema, null);
 
                     _resolvedObjects[arr[0]] = schema;
                 }
 
                 var result = _resolvedObjects[arr[0]];
-                return arr.Length == 1 ? result : await ResolveReferenceAsync(result, "#" + arr[1]).ConfigureAwait(false);
+                return arr.Length == 1
+                    ? result
+                    : await ResolveReferenceAsync(result, "#" + arr[1]).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                throw new InvalidOperationException("Could not resolve the JSON path '" + jsonPath + "' with the full JSON path '" + fullJsonPath + "'.", exception);
+                throw new InvalidOperationException(
+                    "Could not resolve the JSON path '" + jsonPath + "' with the full JSON path '" + fullJsonPath +
+                    "'.", exception);
             }
         }
 
-        private IJsonReference ResolveDocumentReference(object obj, List<string> segments, HashSet<object> checkedObjects)
+        private IJsonReference ResolveDocumentReference(object obj, List<string> segments,
+            HashSet<object> checkedObjects)
         {
             if (obj == null || obj is string || checkedObjects.Contains(obj))
                 return null;
 
             if (obj is IJsonReference reference && reference.Reference != null)
             {
-                var result = ResolveDocumentReferenceWithoutDereferencing(reference.Reference, segments, checkedObjects);
+                var result =
+                    ResolveDocumentReferenceWithoutDereferencing(reference.Reference, segments, checkedObjects);
                 if (result == null)
                     return ResolveDocumentReferenceWithoutDereferencing(obj, segments, checkedObjects);
                 else
@@ -195,7 +221,8 @@ namespace NJsonSchema
             return ResolveDocumentReferenceWithoutDereferencing(obj, segments, checkedObjects);
         }
 
-        private IJsonReference ResolveDocumentReferenceWithoutDereferencing(object obj, List<string> segments, HashSet<object> checkedObjects)
+        private IJsonReference ResolveDocumentReferenceWithoutDereferencing(object obj, List<string> segments,
+            HashSet<object> checkedObjects)
         {
             if (segments.Count == 0)
                 return obj as IJsonReference;
@@ -205,8 +232,8 @@ namespace NJsonSchema
 
             if (obj is IDictionary)
             {
-                if (((IDictionary)obj).Contains(firstSegment))
-                    return ResolveDocumentReference(((IDictionary)obj)[firstSegment], segments.Skip(1).ToList(),
+                if (((IDictionary) obj).Contains(firstSegment))
+                    return ResolveDocumentReference(((IDictionary) obj)[firstSegment], segments.Skip(1).ToList(),
                         checkedObjects);
             }
             else if (obj is IEnumerable)
@@ -214,7 +241,7 @@ namespace NJsonSchema
                 int index;
                 if (int.TryParse(firstSegment, out index))
                 {
-                    var enumerable = ((IEnumerable)obj).Cast<object>().ToArray();
+                    var enumerable = ((IEnumerable) obj).Cast<object>().ToArray();
                     if (enumerable.Length > index)
                         return ResolveDocumentReference(enumerable[index], segments.Skip(1).ToList(), checkedObjects);
                 }
@@ -242,5 +269,12 @@ namespace NJsonSchema
 
             return null;
         }
+    }
+
+    /// <summary>JSON Pointer references resolver settings  </summary>
+    public class JsonReferenceResolverSettings
+    {
+        /// <summary>Function to transfor source references data. </summary>
+        public Func<string, string> TransformationFunction { get; set; }
     }
 }


### PR DESCRIPTION
Proposed fix for https://github.com/RSuter/NJsonSchema/issues/736

Injects source transformation function into `JsonReferenceResolver` throug overloads of `JsonSchema4.FromJsonAsync()`, `JsonSchema4.FromFileAsync()` and `JsonSchema4.FromUrlAsync()` methods.