### PR TITLE
Dictionary key as object for TS v2.1 and higher

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpDictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/CSharpDictionaryTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.CodeGeneration.CSharp.Tests
+{
+    public class CSharpDictionaryTests
+    {
+        public enum PropertyName
+        {
+            Name,
+            Gender
+        }
+
+        public class EnumKeyDictionaryTest
+        {
+            public Dictionary<PropertyName, string> Mapping { get; set; }
+
+            public IDictionary<PropertyName, string> Mapping2 { get; set; }
+        }
+
+        [Fact]
+        public async Task When_dictionary_key_is_enum_then_csharp_has_enum_key()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<EnumKeyDictionaryTest>();
+            var data = schema.ToJson();
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings());
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("public System.Collections.Generic.Dictionary<PropertyName, string> Mapping\n", code);
+            Assert.Contains("public System.Collections.Generic.Dictionary<PropertyName, string> Mapping2\n", code);
+        }
+    }
+}

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpTypeResolver.cs
@@ -159,8 +159,9 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         private string ResolveDictionary(JsonSchema4 schema)
         {
-            var valueType = ResolveDictionaryValueType(schema, "object", Settings.SchemaType);
-            return string.Format(Settings.DictionaryType + "<string, {0}>", valueType);
+            var valueType = ResolveDictionaryValueType(schema, "object");
+            var keyType = ResolveDictionaryKeyType(schema, "string");
+            return string.Format(Settings.DictionaryType + "<{0}, {1}>", keyType, valueType);
         }
     }
 }

--- a/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript.Tests/TypeScriptDictionaryTests.cs
@@ -38,6 +38,22 @@ namespace NJsonSchema.CodeGeneration.TypeScript.Tests
             Assert.Contains("Mapping2: { [key: string] : string; };", code);
         }
 
+        [Fact]
+        public async Task When_dictionary_key_is_enum_then_typescript_has_enum_key_ts_2_1()
+        {
+            //// Arrange
+            var schema = await JsonSchema4.FromTypeAsync<EnumKeyDictionaryTest>();
+            var data = schema.ToJson();
+
+            //// Act
+            var generator = new TypeScriptGenerator(schema, new TypeScriptGeneratorSettings { TypeStyle = TypeScriptTypeStyle.Interface, TypeScriptVersion = 2.1m });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("Mapping: { [key in keyof typeof PropertyName] : string; } | undefined;", code);
+            Assert.Contains("Mapping2: { [key in keyof typeof PropertyName] : string; } | undefined;", code);
+        }
+
         [JsonConverter(typeof(StringEnumConverter))]
         public enum Gender
         {

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -96,11 +96,20 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
             if (schema.IsDictionary)
             {
+                var defaultType = "string";
+
                 var prefix = addInterfacePrefix &&
                     SupportsConstructorConversion(schema.AdditionalPropertiesSchema) &&
                     schema.AdditionalPropertiesSchema?.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true ? "I" : "";
+
                 var valueType = prefix + ResolveDictionaryValueType(schema, "any", Settings.SchemaType);
-                return $"{{ [key: string] : {valueType}; }}";
+                var keyType = this.Settings.TypeScriptVersion >= 2.1m ? prefix + ResolveDictionaryKeyType(schema, defaultType, Settings.SchemaType): defaultType;
+
+                if (keyType == defaultType) {
+                    return $"{{ [key: {keyType}] : {valueType}; }}";
+                }
+
+                return $"{{ [key in keyof typeof {keyType}] : {valueType}; }}";
             }
 
             return (addInterfacePrefix && SupportsConstructorConversion(schema) ? "I" : "") +

--- a/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/TypeScriptTypeResolver.cs
@@ -96,24 +96,24 @@ namespace NJsonSchema.CodeGeneration.TypeScript
 
             if (schema.IsDictionary)
             {
-                var defaultType = "string";
-
                 var prefix = addInterfacePrefix &&
                     SupportsConstructorConversion(schema.AdditionalPropertiesSchema) &&
                     schema.AdditionalPropertiesSchema?.ActualSchema.Type.HasFlag(JsonObjectType.Object) == true ? "I" : "";
 
-                var valueType = prefix + ResolveDictionaryValueType(schema, "any", Settings.SchemaType);
-                var keyType = this.Settings.TypeScriptVersion >= 2.1m ? prefix + ResolveDictionaryKeyType(schema, defaultType, Settings.SchemaType): defaultType;
+                var valueType = prefix + ResolveDictionaryValueType(schema, "any");
 
-                if (keyType == defaultType) {
-                    return $"{{ [key: {keyType}] : {valueType}; }}";
+                var defaultType = "string";
+                var keyType = Settings.TypeScriptVersion >= 2.1m ? prefix + ResolveDictionaryKeyType(schema, defaultType) : defaultType;
+                if (keyType != defaultType)
+                {
+                    return $"{{ [key in keyof typeof {keyType}] : {valueType}; }}";
                 }
 
-                return $"{{ [key in keyof typeof {keyType}] : {valueType}; }}";
+                return $"{{ [key: {keyType}] : {valueType}; }}";
             }
 
             return (addInterfacePrefix && SupportsConstructorConversion(schema) ? "I" : "") +
-                base.GetOrGenerateTypeName(schema, typeNameHint);
+                GetOrGenerateTypeName(schema, typeNameHint);
         }
 
         private string ResolveString(JsonSchema4 schema, string typeNameHint)

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -82,22 +82,25 @@ namespace NJsonSchema.CodeGeneration
         /// <summary>Resolves the type of the dictionary value of the given schema (must be a dictionary schema).</summary>
         /// <param name="schema">The schema.</param>
         /// <param name="fallbackType">The fallback type (e.g. 'object').</param>
-        /// <param name="schemaType">The schema type.</param>
         /// <returns>The type.</returns>
-        protected string ResolveDictionaryValueType(JsonSchema4 schema, string fallbackType, SchemaType schemaType)
+        protected string ResolveDictionaryValueType(JsonSchema4 schema, string fallbackType)
         {
             if (schema.AdditionalPropertiesSchema != null)
-                return Resolve(schema.AdditionalPropertiesSchema, schema.AdditionalPropertiesSchema.ActualSchema.IsNullable(schemaType), null);
+            {
+                return Resolve(schema.AdditionalPropertiesSchema, schema.AdditionalPropertiesSchema.ActualSchema.IsNullable(_settings.SchemaType), null);
+            }
 
             if (schema.AllowAdditionalProperties == false && schema.PatternProperties.Any())
             {
                 var valueTypes = schema.PatternProperties
-                    .Select(p => Resolve(p.Value, p.Value.IsNullable(schemaType), null))
+                    .Select(p => Resolve(p.Value, p.Value.IsNullable(_settings.SchemaType), null))
                     .Distinct()
                     .ToList();
 
                 if (valueTypes.Count == 1)
+                {
                     return valueTypes.First();
+                }
             }
 
             return fallbackType;
@@ -106,12 +109,13 @@ namespace NJsonSchema.CodeGeneration
         /// <summary>Resolves the type of the dictionary key of the given schema (must be a dictionary schema).</summary>
         /// <param name="schema">The schema.</param>
         /// <param name="fallbackType">The fallback type (e.g. 'object').</param>
-        /// <param name="schemaType">The schema type.</param>
         /// <returns>The type.</returns>
-        protected string ResolveDictionaryKeyType(JsonSchema4 schema, string fallbackType, SchemaType schemaType)
+        protected string ResolveDictionaryKeyType(JsonSchema4 schema, string fallbackType)
         {
-            if (schema.Item != null)
-                return Resolve(schema.Item, schema.Item.ActualSchema.IsNullable(schemaType), null);
+            if (schema.KeySchema != null)
+            {
+                return Resolve(schema.KeySchema, schema.KeySchema.ActualSchema.IsNullable(_settings.SchemaType), null);
+            }
 
             return fallbackType;
         }

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -112,9 +112,9 @@ namespace NJsonSchema.CodeGeneration
         /// <returns>The type.</returns>
         protected string ResolveDictionaryKeyType(JsonSchema4 schema, string fallbackType)
         {
-            if (schema.KeySchema != null)
+            if (schema.DictionaryKey != null)
             {
-                return Resolve(schema.KeySchema, schema.KeySchema.ActualSchema.IsNullable(_settings.SchemaType), null);
+                return Resolve(schema.DictionaryKey, schema.DictionaryKey.ActualSchema.IsNullable(_settings.SchemaType), null);
             }
 
             return fallbackType;

--- a/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
+++ b/src/NJsonSchema.CodeGeneration/TypeResolverBase.cs
@@ -102,5 +102,18 @@ namespace NJsonSchema.CodeGeneration
 
             return fallbackType;
         }
+
+        /// <summary>Resolves the type of the dictionary key of the given schema (must be a dictionary schema).</summary>
+        /// <param name="schema">The schema.</param>
+        /// <param name="fallbackType">The fallback type (e.g. 'object').</param>
+        /// <param name="schemaType">The schema type.</param>
+        /// <returns>The type.</returns>
+        protected string ResolveDictionaryKeyType(JsonSchema4 schema, string fallbackType, SchemaType schemaType)
+        {
+            if (schema.Item != null)
+                return Resolve(schema.Item, schema.Item.ActualSchema.IsNullable(schemaType), null);
+
+            return fallbackType;
+        }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
+++ b/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
@@ -28,10 +28,10 @@ namespace NJsonSchema.Tests.Generation
 
             //// Assert
             Assert.True(schema.Properties["Mapping"].IsDictionary);
-            Assert.True(schema.Properties["Mapping"].KeySchema.ActualSchema.IsEnumeration);
+            Assert.True(schema.Properties["Mapping"].DictionaryKey.ActualSchema.IsEnumeration);
 
             Assert.True(schema.Properties["Mapping2"].IsDictionary);
-            Assert.True(schema.Properties["Mapping2"].KeySchema.ActualSchema.IsEnumeration);
+            Assert.True(schema.Properties["Mapping2"].DictionaryKey.ActualSchema.IsEnumeration);
         }
     }
 }

--- a/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
+++ b/src/NJsonSchema.Tests/Generation/DictionaryTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NJsonSchema.Tests.Generation
+{
+    public class DictionaryTests
+    {
+        public enum PropertyName
+        {
+            Name,
+            Gender
+        }
+
+        public class EnumKeyDictionaryTest
+        {
+            public Dictionary<PropertyName, string> Mapping { get; set; }
+
+            public IDictionary<PropertyName, string> Mapping2 { get; set; }
+        }
+
+        [Fact]
+        public async Task When_dictionary_key_is_enum_then_csharp_has_enum_key()
+        {
+            //// Act
+            var schema = await JsonSchema4.FromTypeAsync<EnumKeyDictionaryTest>();
+            var data = schema.ToJson();
+
+            //// Assert
+            Assert.True(schema.Properties["Mapping"].IsDictionary);
+            Assert.True(schema.Properties["Mapping"].KeySchema.ActualSchema.IsEnumeration);
+
+            Assert.True(schema.Properties["Mapping2"].IsDictionary);
+            Assert.True(schema.Properties["Mapping2"].KeySchema.ActualSchema.IsEnumeration);
+        }
+    }
+}

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -465,7 +465,24 @@ namespace NJsonSchema.Generation
         {
             var genericTypeArguments = type.GetGenericTypeArguments();
 
+            var keyType = genericTypeArguments.Length == 2 ? genericTypeArguments[0] : typeof(string);
+
+            if (keyType != typeof(string)) {
+                var itemSchema = await GenerateAsync(keyType, schemaResolver).ConfigureAwait(false);
+                var valueTypeDescription = Settings.ReflectionService.GetDescription(keyType, null, Settings);
+                if (valueTypeDescription.RequiresSchemaReference(Settings.TypeMappers))
+                {
+                    schema.Item = new JsonSchema4
+                    {
+                        Reference = itemSchema
+                    };
+                }
+                else
+                    schema.Item = itemSchema;
+            }
+
             var valueType = genericTypeArguments.Length == 2 ? genericTypeArguments[1] : typeof(object);
+
             if (valueType == typeof(object))
                 schema.AdditionalPropertiesSchema = JsonSchema4.CreateAnySchema();
             else

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -466,28 +466,33 @@ namespace NJsonSchema.Generation
             var genericTypeArguments = type.GetGenericTypeArguments();
 
             var keyType = genericTypeArguments.Length == 2 ? genericTypeArguments[0] : typeof(string);
+            if (keyType.GetTypeInfo().IsEnum)
+            {
+                var keySchema = await GenerateAsync(keyType, schemaResolver).ConfigureAwait(false);
 
-            if (keyType != typeof(string)) {
-                var itemSchema = await GenerateAsync(keyType, schemaResolver).ConfigureAwait(false);
                 var valueTypeDescription = Settings.ReflectionService.GetDescription(keyType, null, Settings);
                 if (valueTypeDescription.RequiresSchemaReference(Settings.TypeMappers))
                 {
-                    schema.Item = new JsonSchema4
+                    schema.KeySchema = new JsonSchema4
                     {
-                        Reference = itemSchema
+                        Reference = keySchema
                     };
                 }
                 else
-                    schema.Item = itemSchema;
+                {
+                    schema.KeySchema = keySchema;
+                }
             }
 
             var valueType = genericTypeArguments.Length == 2 ? genericTypeArguments[1] : typeof(object);
-
             if (valueType == typeof(object))
+            {
                 schema.AdditionalPropertiesSchema = JsonSchema4.CreateAnySchema();
+            }
             else
             {
                 var additionalPropertiesSchema = await GenerateAsync(valueType, schemaResolver).ConfigureAwait(false);
+
                 var valueTypeDescription = Settings.ReflectionService.GetDescription(valueType, null, Settings);
                 if (valueTypeDescription.RequiresSchemaReference(Settings.TypeMappers))
                 {
@@ -497,7 +502,9 @@ namespace NJsonSchema.Generation
                     };
                 }
                 else
+                {
                     schema.AdditionalPropertiesSchema = additionalPropertiesSchema;
+                }
             }
 
             schema.AllowAdditionalProperties = true;
@@ -711,7 +718,7 @@ namespace NJsonSchema.Generation
                     var discriminatorName = TryGetInheritanceDiscriminatorName(discriminatorConverter);
 
                     // Existing property can be discriminator only if it has String type  
-                    if (schema.Properties.TryGetValue(discriminatorName, out JsonProperty existingProperty) && 
+                    if (schema.Properties.TryGetValue(discriminatorName, out JsonProperty existingProperty) &&
                         (existingProperty.Type & JsonObjectType.String) == 0)
                     {
                         throw new InvalidOperationException("The JSON discriminator property '" + discriminatorName + "' must be a string property on type '" + type.FullName + "' (it is recommended to not implement the discriminator property at all).");

--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -473,14 +473,14 @@ namespace NJsonSchema.Generation
                 var valueTypeDescription = Settings.ReflectionService.GetDescription(keyType, null, Settings);
                 if (valueTypeDescription.RequiresSchemaReference(Settings.TypeMappers))
                 {
-                    schema.KeySchema = new JsonSchema4
+                    schema.DictionaryKey = new JsonSchema4
                     {
                         Reference = keySchema
                     };
                 }
                 else
                 {
-                    schema.KeySchema = keySchema;
+                    schema.DictionaryKey = keySchema;
                 }
             }
 

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -36,7 +36,7 @@ namespace NJsonSchema
         private ICollection<JsonSchema4> _anyOf;
         private ICollection<JsonSchema4> _oneOf;
         private JsonSchema4 _not;
-        private JsonSchema4 _keySchema;
+        private JsonSchema4 _dictionaryKey;
 
         private JsonSchema4 _item;
         private ICollection<JsonSchema4> _items;
@@ -426,15 +426,15 @@ namespace NJsonSchema
         #region Child JSON schemas
 
         /// <summary>Gets or sets the dictionary key schema (x-key, only enum schemas are allowed).</summary>
-        [JsonProperty("x-key", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public JsonSchema4 KeySchema
+        [JsonProperty("x-dictionaryKey", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public JsonSchema4 DictionaryKey
         {
-            get { return _keySchema; }
+            get { return _dictionaryKey; }
             set
             {
-                _keySchema = value;
-                if (_keySchema != null)
-                    _keySchema.Parent = this;
+                _dictionaryKey = value;
+                if (_dictionaryKey != null)
+                    _dictionaryKey.Parent = this;
             }
         }
 

--- a/src/NJsonSchema/JsonSchema4.cs
+++ b/src/NJsonSchema/JsonSchema4.cs
@@ -36,6 +36,7 @@ namespace NJsonSchema
         private ICollection<JsonSchema4> _anyOf;
         private ICollection<JsonSchema4> _oneOf;
         private JsonSchema4 _not;
+        private JsonSchema4 _keySchema;
 
         private JsonSchema4 _item;
         private ICollection<JsonSchema4> _items;
@@ -423,6 +424,19 @@ namespace NJsonSchema
         public ICollection<string> RequiredProperties { get; internal set; }
 
         #region Child JSON schemas
+
+        /// <summary>Gets or sets the dictionary key schema (x-key, only enum schemas are allowed).</summary>
+        [JsonProperty("x-key", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public JsonSchema4 KeySchema
+        {
+            get { return _keySchema; }
+            set
+            {
+                _keySchema = value;
+                if (_keySchema != null)
+                    _keySchema.Parent = this;
+            }
+        }
 
         /// <summary>Gets the properties of the type. </summary>
         [JsonIgnore]


### PR DESCRIPTION
Adds x-dictionaryKey to JSON Schema for dictionaries with an enum key, so that the enum is retained when generating TS or C#. 

Closes https://github.com/RSuter/NSwag/issues/1507