### PR TITLE
EnumHandling.Integer mode bug fixed

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -757,7 +757,7 @@ namespace NJsonSchema.Generation
 
             var underlyingType = Enum.GetUnderlyingType(type);
 
-            var converters = Settings.ActualSerializerSettings.Converters;
+            var converters = Settings.ActualSerializerSettings.Converters.ToList();
             if (!converters.OfType<StringEnumConverter>().Any())
                 converters.Add(new StringEnumConverter());
 


### PR DESCRIPTION
EnumHandling.Integer does not work if more than one enum present in models

Global converter check is here:
https://github.com/RSuter/NJsonSchema/blob/3e1185fe5799f7211661f71adb03fb304db51819/src/NJsonSchema/Generation/DefaultReflectionService.cs#L272

Initial converter's collection changed here:
https://github.com/RSuter/NJsonSchema/blob/e93b5af71c853e886335f028a42d22bb32784354/src/NJsonSchema/Generation/JsonSchemaGenerator.cs#L762