### PR TITLE
Fix JToken type handling in JsonSchemaGenerator

### DIFF
--- a/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
+++ b/src/NJsonSchema/Generation/JsonSchemaGenerator.cs
@@ -426,7 +426,7 @@ namespace NJsonSchema.Generation
                 return true;
             }
 
-            if (type == typeof(JObject) || type == typeof(JToken) || type == typeof(object))
+            if (type.IsAssignableTo("JToken", TypeNameStyle.Name) || type == typeof(object))
                 return true;
 
             return false;


### PR DESCRIPTION
Now every type that is assignable to Linqu.JToken will be handled as special Type

See https://github.com/RSuter/NSwag/issues/1751