### PR TITLE
Fix stackoverflow in GetEnumerableItemType

### DIFF
--- a/src/NJsonSchema/Infrastructure/ReflectionExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/ReflectionExtensions.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -128,9 +129,13 @@ namespace NJsonSchema.Infrastructure
                 foreach (var iface in type.GetTypeInfo().GetInterfaces())
 #endif
                 {
-                    itemType = GetEnumerableItemType(iface);
-                    if (itemType != null)
-                        return itemType;
+                    if (typeof(IEnumerable).GetTypeInfo()
+                        .IsAssignableFrom(iface.GetTypeInfo()))
+                    {
+                        itemType = GetEnumerableItemType(iface);
+                        if (itemType != null)
+                            return itemType;
+                    }
                 }
             }
             return itemType;


### PR DESCRIPTION
Fixes issue https://github.com/RSuter/NJsonSchema/issues/842

I simply adds a check in `GetEnumerableItemType` when going through the interface of a type to only consider the one that implement `IEnumerable`.