### PR TITLE
Modify GetXmlDocumentationPathAsync

### DIFF
--- a/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
@@ -521,9 +521,6 @@ namespace NJsonSchema.Infrastructure
                 if (assembly == null)
                     return null;
 
-                if (string.IsNullOrEmpty(assembly.Location))
-                    return null;
-
                 var assemblyName = assembly.GetName();
                 if (string.IsNullOrEmpty(assemblyName.Name))
                     return null;
@@ -531,10 +528,14 @@ namespace NJsonSchema.Infrastructure
                 if (Cache.ContainsKey(assemblyName.FullName))
                     return null;
 
-                var assemblyDirectory = DynamicApis.PathGetDirectoryName((string)assembly.Location);
-                var path = DynamicApis.PathCombine(assemblyDirectory, (string)assemblyName.Name + ".xml");
-                if (await DynamicApis.FileExistsAsync(path).ConfigureAwait(false))
-                    return path;
+                string path;
+                if (!string.IsNullOrEmpty(assembly.Location))
+                {
+                    var assemblyDirectory = DynamicApis.PathGetDirectoryName((string)assembly.Location);
+                    path = DynamicApis.PathCombine(assemblyDirectory, (string)assemblyName.Name + ".xml");
+                    if (await DynamicApis.FileExistsAsync(path).ConfigureAwait(false))
+                        return path;
+                }
 
                 if (ReflectionExtensions.HasProperty(assembly, "CodeBase"))
                 {


### PR DESCRIPTION
If there is not a location for an assembly, then the code will continue, instead of returning null in GetXmlDocumentationPathAsync