### PR TITLE
If assembly location is not found, then return current directory path in GetXmlDocumentationPathAsync

### DIFF
--- a/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
@@ -516,6 +516,7 @@ namespace NJsonSchema.Infrastructure
 
         private static async Task<string> GetXmlDocumentationPathAsync(dynamic assembly)
         {
+            string path;
             try
             {
                 if (assembly == null)
@@ -528,7 +529,6 @@ namespace NJsonSchema.Infrastructure
                 if (Cache.ContainsKey(assemblyName.FullName))
                     return null;
 
-                string path;
                 if (!string.IsNullOrEmpty(assembly.Location))
                 {
                     var assemblyDirectory = DynamicApis.PathGetDirectoryName((string)assembly.Location);
@@ -562,6 +562,11 @@ namespace NJsonSchema.Infrastructure
             }
             catch
             {
+                var currentDirectory = await DynamicApis.DirectoryGetCurrentDirectoryAsync();
+                path = DynamicApis.PathCombine(currentDirectory, "bin\\" + assembly.GetName().Name + ".xml");
+                if (await DynamicApis.FileExistsAsync(path).ConfigureAwait(false))
+                    return path;
+
                 return null;
             }
         }

--- a/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
+++ b/src/NJsonSchema/Infrastructure/XmlDocumentationExtensions.cs
@@ -562,11 +562,26 @@ namespace NJsonSchema.Infrastructure
             }
             catch
             {
+                // ignored
+            }
+
+            try
+            {
                 var currentDirectory = await DynamicApis.DirectoryGetCurrentDirectoryAsync();
+                path = DynamicApis.PathCombine(currentDirectory, assembly.GetName().Name + ".xml");
+                if (await DynamicApis.FileExistsAsync(path).ConfigureAwait(false))
+                {
+                    return path;
+                }
+
                 path = DynamicApis.PathCombine(currentDirectory, "bin\\" + assembly.GetName().Name + ".xml");
                 if (await DynamicApis.FileExistsAsync(path).ConfigureAwait(false))
                     return path;
 
+                return null;
+            }
+            catch
+            {
                 return null;
             }
         }


### PR DESCRIPTION
In GetXmlDocumentationPathAsync method, assembly.Location or assembly.CodeBase may throw errors or so, in such a case, in the catch block get the current working directory path and return it if the regarding xml file exists.