### PR TITLE
Add a license expression to the nuspec

### DIFF
--- a/src/NJsonSchema/NJsonSchema.nuspec
+++ b/src/NJsonSchema/NJsonSchema.nuspec
@@ -7,7 +7,6 @@
     <description>$description$</description>
     <tags>json schema validation generator .net</tags>
     <projectUrl>http://NJsonSchema.org</projectUrl>
-    <licenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</licenseUrl>
     <license type="expression">MIT</license>
   </metadata>
   <files>

--- a/src/NJsonSchema/NJsonSchema.nuspec
+++ b/src/NJsonSchema/NJsonSchema.nuspec
@@ -8,6 +8,7 @@
     <tags>json schema validation generator .net</tags>
     <projectUrl>http://NJsonSchema.org</projectUrl>
     <licenseUrl>https://github.com/rsuter/NJsonSchema/blob/master/LICENSE.md</licenseUrl>
+    <license type="expression">MIT</license>
   </metadata>
   <files>
     <file src="bin\Release\NJsonSchema.dll" target="lib\portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />


### PR DESCRIPTION
A project I work on uses https://clearlydefined.io to generate a third party notices file and it is having trouble detecting your license type.

They said that this change should help resolve the issue.

Thanks