### PR TITLE
Fix file resolve when relative file initial file is added

### DIFF
--- a/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
+++ b/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
@@ -29,7 +29,7 @@ namespace NJsonSchema.Tests.References
 		}
 	}
 }";
-            
+
             //// Act
             var schema = await JsonSchema4.FromJsonAsync(json);
             var j = schema.ToJson();
@@ -89,31 +89,33 @@ namespace NJsonSchema.Tests.References
             //// Arrange
             var externalSchema = await JsonSchema4.FromJsonAsync(
             @"{
-                    ""type"": ""object"", 
-                    ""properties"": {
-                        ""foo"": {
-                            ""type"": ""string""
-                       }
-                     }
-                   }");
+                ""type"": ""object"", 
+                ""properties"": {
+                    ""foo"": {
+                        ""type"": ""string""
+                    }
+                }
+            }");
 
             Func<JsonSchema4, JsonReferenceResolver> factory = schema4 =>
-                {
-                    var schemaResolver = new JsonSchemaResolver(schema4, new JsonSchemaGeneratorSettings());
-                    var resolver = new JsonReferenceResolver(schemaResolver);
-                    resolver.AddDocumentReference("../dir/external.json", externalSchema);
-                    return resolver;
-                };
+            {
+                var schemaResolver = new JsonSchemaResolver(schema4, new JsonSchemaGeneratorSettings());
+                var resolver = new JsonReferenceResolver(schemaResolver);
+                resolver.AddDocumentReference("../dir/external.json", externalSchema);
+                return resolver;
+            };
 
-            string schemaJson = @"{
-                                    ""$schema"": ""http://json-schema.org/draft-07/schema#"",
-                                    ""type"": ""object"",
-                                    ""properties"": {
-                                      ""title"": {
-                                         ""$ref"": ""../dir/external.json#""
-                                      }
-                                    }
-                                 }";
+            string schemaJson =
+            @"{
+                ""$schema"": ""http://json-schema.org/draft-07/schema#"",
+                ""type"": ""object"",
+                ""properties"": {
+                    ""title"": {
+                        ""$ref"": ""../dir/external.json#""
+                    }
+                }
+            }";
+
             //// Act
             var schema = await JsonSchema4.FromJsonAsync(schemaJson, ".", factory);
 

--- a/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
+++ b/src/NJsonSchema.Tests/References/LocalReferencesTests.cs
@@ -6,6 +6,8 @@ using Xunit;
 
 namespace NJsonSchema.Tests.References
 {
+    using NJsonSchema.Generation;
+
     public class LocalReferencesTests
     {
         [Fact]
@@ -79,6 +81,44 @@ namespace NJsonSchema.Tests.References
 
             //// Assert
             Assert.Equal(1, schema.Definitions.Count);
+        }
+
+        [Fact]
+        public async Task When_reference_is_registered_in_custom_resolver_it_should_not_try_to_access_file()
+        {
+            //// Arrange
+            var externalSchema = await JsonSchema4.FromJsonAsync(
+            @"{
+                    ""type"": ""object"", 
+                    ""properties"": {
+                        ""foo"": {
+                            ""type"": ""string""
+                       }
+                     }
+                   }");
+
+            Func<JsonSchema4, JsonReferenceResolver> factory = schema4 =>
+                {
+                    var schemaResolver = new JsonSchemaResolver(schema4, new JsonSchemaGeneratorSettings());
+                    var resolver = new JsonReferenceResolver(schemaResolver);
+                    resolver.AddDocumentReference("../dir/external.json", externalSchema);
+                    return resolver;
+                };
+
+            string schemaJson = @"{
+                                    ""$schema"": ""http://json-schema.org/draft-07/schema#"",
+                                    ""type"": ""object"",
+                                    ""properties"": {
+                                      ""title"": {
+                                         ""$ref"": ""../dir/external.json#""
+                                      }
+                                    }
+                                 }";
+            //// Act
+            var schema = await JsonSchema4.FromJsonAsync(schemaJson, ".", factory);
+
+            //// Assert
+            Assert.NotNull(schema);
         }
 
         private string GetTestDirectory()

--- a/src/NJsonSchema/JsonReferenceResolver.cs
+++ b/src/NJsonSchema/JsonReferenceResolver.cs
@@ -47,7 +47,7 @@ namespace NJsonSchema
         /// <param name="schema">The referenced schema.</param>
         public void AddDocumentReference(string documentPath, IJsonReference schema)
         {
-            _resolvedObjects[documentPath] = schema;
+            _resolvedObjects[documentPath.Contains("://") ? documentPath : DynamicApis.GetFullPath(documentPath)] = schema;
         }
 
         /// <summary>Gets the object from the given JSON path.</summary>


### PR DESCRIPTION
Using a custom resolver with relative paths fails because an attempt is
made to resolve the physical path for this (non-existant) file.
Test for #886 