### PR TITLE
New setting for Asp.NET Core ActionResult type usage in code generation

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -1666,6 +1666,28 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
             Assert.Contains("__1 = -1", types.Artifacts.First().Code);
         }
 
+        [Fact]
+        public void When_aspnet_action_type_defaults_to_false()          
+        {
+            //// Arrange
+            var settings = new CSharpGeneratorSettings();
+            var generator = new CSharpGenerator(null, settings);
+         
+            //// Assert
+            Assert.False(generator.Settings.UseActionResultType);
+        }
+
+        [Fact]
+        public void When_aspnet_action_type_is_defined()
+        {
+            //// Arrange
+            var settings = new CSharpGeneratorSettings{ UseActionResultType = true };
+            var generator = new CSharpGenerator(null, settings);
+
+            //// Assert
+            Assert.True(generator.Settings.UseActionResultType);
+        }
+
         private static void AssertCompile(string code)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(code);

--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpGeneratorSettings.cs
@@ -47,6 +47,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             InlineNamedArrays = false;
             InlineNamedDictionaries = false;
             InlineNamedTuples = true;
+            UseActionResultType = false;
         }
 
         /// <summary>Gets or sets the .NET namespace of the generated types (default: MyNamespace).</summary>
@@ -127,5 +128,8 @@ namespace NJsonSchema.CodeGeneration.CSharp
 
         /// <summary>Gets or sets a value indicating whether named/referenced arrays should be inlined or generated as class with array inheritance.</summary>
         public bool InlineNamedArrays { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether ASP.Net Core ActionResult type is used (default: false).</summary>
+        public bool UseActionResultType { get; set; }
     }
 }


### PR DESCRIPTION
This is related to the NSwag issue 1547 (https://github.com/RSuter/NSwag/issues/1547).
That feature requires a new setting that can be passed in the nswag code generation settings file.