### PR TITLE
Added Replace $ with string.Empty in property name generator (C#)

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/CSharpPropertyNameGenerator.cs
@@ -19,6 +19,7 @@ namespace NJsonSchema.CodeGeneration.CSharp
             return ConversionUtilities.ConvertToUpperCamelCase(property.Name
                     .Replace("\"", string.Empty)
                     .Replace("@", string.Empty)
+                    .Replace("$", string.Empty)
                     .Replace(".", "-")
                     .Replace("=", "-")
                     .Replace("+", "plus"), true)


### PR DESCRIPTION
Fixes https://github.com/RSuter/NSwag/issues/1950