### PR TITLE
Fixed toJSON() serialization of TypeScript objects with Dictionary property

### DIFF
--- a/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScript.liquid
+++ b/src/NJsonSchema.CodeGeneration.TypeScript/Templates/ConvertToJavaScript.liquid
@@ -19,7 +19,7 @@ if ({{ Value }}) {
     {{ Variable }} = {};
     for (let key in {{ Value }}) {
         if ({{ Value }}.hasOwnProperty(key))
-{%     if IsDictionaryValueNewableObjec -%}
+{%     if IsDictionaryValueNewableObject -%}
             {{ Variable }}[key] = {{ Value }}[key] ? {{ Value }}[key].toJSON() : <any>{{ NullValue }};
 {%     elseif IsDictionaryValueDate -%}
             {{ Variable }}[key] = {{ Value }}[key] ? {% if UseJsDate %}formatDate({{ Value }}[key]){% else %}{{ Value }}[key].format('YYYY-MM-DD'){% endif %} : <any>{{ NullValue }};


### PR DESCRIPTION
In the `ConvertToJavaScript.liquid` template, there was a one character typo that was preventing proper generation of the `toJSON()` method for classes with Dictionary properties.

This corrects this error and allows objects to be properly serialized.