### PR TITLE
Allow up to 7 decimal places for fractional seconds in DateTime values

### DIFF
--- a/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
@@ -66,7 +66,7 @@ namespace NJsonSchema.Tests.Validation
             schema.Type = JsonObjectType.String;
             schema.Format = JsonFormatStrings.DateTime;
 
-            var token = new JValue("2015-01-25T15:43:30Z");
+            var token = new JValue("2015-01-25T15:43:30.1234567Z");
 
             //// Act
             var errors = schema.Validate(token);

--- a/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
@@ -93,7 +93,7 @@ namespace NJsonSchema.Tests.Validation
         }
         
         [Fact]
-        public void When_format_date_time_with_iso8601_an_fractional_seconds_then_validation_succeeds()
+        public void When_format_date_time_with_iso8601_and_fractional_seconds_then_validation_succeeds()
         {
             //// Arrange
             var schema = new JsonSchema4();

--- a/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
+++ b/src/NJsonSchema.Tests/Validation/FormatDateTimeTests.cs
@@ -66,7 +66,7 @@ namespace NJsonSchema.Tests.Validation
             schema.Type = JsonObjectType.String;
             schema.Format = JsonFormatStrings.DateTime;
 
-            var token = new JValue("2015-01-25T15:43:30.1234567Z");
+            var token = new JValue("2015-01-25T15:43:30Z");
 
             //// Act
             var errors = schema.Validate(token);
@@ -84,6 +84,23 @@ namespace NJsonSchema.Tests.Validation
             schema.Format = JsonFormatStrings.DateTime;
 
             var token = new JValue("2015-01-25T15:43:30+10:00");
+
+            //// Act
+            var errors = schema.Validate(token);
+
+            //// Assert
+            Assert.Empty(errors);
+        }
+        
+        [Fact]
+        public void When_format_date_time_with_iso8601_an_fractional_seconds_then_validation_succeeds()
+        {
+            //// Arrange
+            var schema = new JsonSchema4();
+            schema.Type = JsonObjectType.String;
+            schema.Format = JsonFormatStrings.DateTime;
+
+            var token = new JValue("2015-01-25T15:43:30.1234567Z");
 
             //// Act
             var errors = schema.Validate(token);

--- a/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
+++ b/src/NJsonSchema/Validation/FormatValidators/DateTimeFormatValidator.cs
@@ -15,8 +15,8 @@ namespace NJsonSchema.Validation.FormatValidators
     public class DateTimeFormatValidator : IFormatValidator
     {
         private readonly string[] _acceptableFormats = new [] {
-            "yyyy-MM-dd'T'HH:mm:ss.FFFK",
-            "yyyy-MM-dd' 'HH:mm:ss.FFFK",
+            "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
+            "yyyy-MM-dd' 'HH:mm:ss.FFFFFFFK",
             "yyyy-MM-dd'T'HH:mm:ssK",
             "yyyy-MM-dd' 'HH:mm:ssK",
             "yyyy-MM-dd'T'HH:mm:ss",


### PR DESCRIPTION
`Json.NET` defaults to 7 decimal places when serializing `DateTime` values. It would be nice to accommodate that.