### PR TITLE
Adds support for MinLength and MaxLength attributes

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp.Tests/GeneralGeneratorTests.cs
@@ -1161,6 +1161,38 @@ namespace NJsonSchema.CodeGeneration.CSharp.Tests
         }
 
         [Fact]
+        public async Task When_definition_contains_both_min_items_and_max_items_a_min_length_and_max_length_attributes_are_added_only_for_type_array()
+        {
+            //// Arrange
+            var json =
+                @"{
+	""type"": ""object"", 
+	""properties"": {
+		""foo"": {
+		  ""type"": ""array"",
+		  ""minItems"": ""10"",
+		  ""maxItems"": ""20""
+        }
+	}
+}";
+            var schema = await JsonSchema4.FromJsonAsync(json);
+
+            //// Act
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings
+            {
+                ClassStyle = CSharpClassStyle.Poco,
+                SchemaType = SchemaType.Swagger2
+            });
+            var code = generator.GenerateFile("MyClass");
+
+            //// Assert
+            Assert.Contains("System.ComponentModel.DataAnnotations.MinLength(10)", code);
+            Assert.Contains("System.ComponentModel.DataAnnotations.MaxLength(20)", code);
+
+            AssertCompile(code);
+        }
+
+        [Fact]
         public async Task When_definition_contains_pattern_a_regular_expression_attribute_is_added()
         {
             //// Arrange

--- a/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Models/PropertyModel.cs
@@ -180,6 +180,36 @@ namespace NJsonSchema.CodeGeneration.CSharp.Models
         /// <summary>Gets the maximum value of the string length attribute.</summary>
         public string StringLengthMaximumValue => _property.MaxLength.HasValue ? _property.MaxLength.Value.ToString(CultureInfo.InvariantCulture) : $"int.{nameof(int.MaxValue)}";
 
+        /// <summary>Gets a value indicating whether to render the min length attribute.</summary>
+        public bool RenderMinLengthAttribute
+        {
+            get
+            {
+                if (!_settings.GenerateDataAnnotations)
+                    return false;
+
+                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.MinItems > 0;
+            }
+        }
+
+        /// <summary>Gets the value of the min length attribute.</summary>
+        public int MinLengthAttribute => _property.MinItems;
+
+        /// <summary>Gets a value indicating whether to render the max length attribute.</summary>
+        public bool RenderMaxLengthAttribute
+        {
+            get
+            {
+                if (!_settings.GenerateDataAnnotations)
+                    return false;
+
+                return _property.ActualTypeSchema.Type.HasFlag(JsonObjectType.Array) && _property.MaxItems > 0;
+            }
+        }
+
+        /// <summary>Gets the value of the max length attribute.</summary>
+        public int MaxLengthAttribute => _property.MaxItems;
+
         /// <summary>Gets a value indicating whether to render a regular expression attribute.</summary>
         public bool RenderRegularExpressionAttribute
         {

--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -45,6 +45,12 @@
 {%   if property.RenderStringLengthAttribute -%}
     [System.ComponentModel.DataAnnotations.StringLength({{ property.StringLengthMaximumValue }}{% if property.StringLengthMinimumValue > 0 %}, MinimumLength = {{ property.StringLengthMinimumValue }}{% endif %})]
 {%   endif -%}
+{%   if property.RenderMinLengthAttribute -%}
+    [System.ComponentModel.DataAnnotations.MinLength({{ property.MinLengthAttribute }})]
+{%   endif -%}
+{%   if property.RenderMaxLengthAttribute -%}
+    [System.ComponentModel.DataAnnotations.MaxLength({{ property.MaxLengthAttribute }})]
+{%   endif -%}
 {%   if property.RenderRegularExpressionAttribute -%}
     [System.ComponentModel.DataAnnotations.RegularExpression(@"{{ property.RegularExpressionValue }}")]
 {%   endif -%}

--- a/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultEnumNameGenerator.cs
@@ -19,6 +19,11 @@ namespace NJsonSchema.CodeGeneration
         /// <returns>The enumeration name.</returns>
         public string Generate(int index, string name, object value, JsonSchema4 schema)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                return "Empty";
+            }
+
             if (name.StartsWith("_-"))
             {
                 name = "__" + name.Substring(2);

--- a/src/NJsonSchema.Tests/Generation/AnnotationsGenerationTests.cs
+++ b/src/NJsonSchema.Tests/Generation/AnnotationsGenerationTests.cs
@@ -236,6 +236,48 @@ namespace NJsonSchema.Tests.Generation
             Assert.Equal(10, property.MaxLength);
         }
 
+        public class MinLengthAttributeClass
+        {
+            [MinLength(1)]
+            public int[] Items { get; set; }
+
+            [MinLength(50)]
+            public string Foo { get; set; }
+        }
+
+        [Fact]
+        public async Task When_MinLengthAttribute_is_set_then_minItems_or_minLength_is_set()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<MinLengthAttributeClass>();
+
+            var arrayProperty = schema.Properties["Items"];
+            Assert.Equal(1, arrayProperty.MinItems);
+
+            var stringProperty = schema.Properties["Foo"];
+            Assert.Equal(50, stringProperty.MinLength);
+        }
+
+        public class MaxLengthAttributeClass
+        {
+            [MaxLength(100)]
+            public int[] Items { get; set; }
+
+            [MaxLength(500)]
+            public string Foo { get; set; }
+        }
+
+        [Fact]
+        public async Task When_MaxLengthAttribute_is_set_then_maxItems_or_maxLength_is_set()
+        {
+            var schema = await JsonSchema4.FromTypeAsync<MaxLengthAttributeClass>();
+
+            var arrayProperty = schema.Properties["Items"];
+            Assert.Equal(100, arrayProperty.MaxItems);
+
+            var stringProperty = schema.Properties["Foo"];
+            Assert.Equal(500, stringProperty.MaxLength);
+        }
+
         public class StringRequiredClass
         {
             [Required(AllowEmptyStrings = false)]


### PR DESCRIPTION
* Adds support for MinLength and MaxLength attributes when generating CSharp classes.

The generated class will have the System.ComponentModel.DataAnnotations.MinLength and System.ComponentModel.DataAnnotations.MaxLength added when the minItems and maxItems are specified in the schema.
Example:
```cs
public class Person
{
    [Required]
    public string FirstName { get; set; }

    public string MiddleName { get; set; }

    [Required]
    public string LastName { get; set; }

    public Gender Gender { get; set; }

    [Range(2, 5)]
    public int NumberWithRange { get; set; }

    public DateTime Birthday { get; set; }

    public Company Company { get; set; }

    [MinLength(1)]
    [MaxLength(20)]
    public Collection<Car> Cars { get; set; }
}
```